### PR TITLE
Add module-level docstring explaining type validation strategy

### DIFF
--- a/src/budget_tracker/model.py
+++ b/src/budget_tracker/model.py
@@ -1,3 +1,16 @@
+"""
+Domain models for budget tracking.
+
+Type Validation Strategy:
+    All monetary values (amounts, balances) must be Decimal instances.
+    This is enforced at runtime in constructors and public methods to:
+    - Prevent floating-point precision issues in financial calculations
+    - Catch type errors early (fail-fast principle)
+    - Ensure domain model integrity regardless of caller
+
+    The API layer uses Pydantic which handles JSON-to-Decimal conversion
+    before values reach the domain layer.
+"""
 from __future__ import annotations
 
 from decimal import Decimal


### PR DESCRIPTION
Add comprehensive documentation explaining the strict Decimal type enforcement strategy used in the domain layer, covering:
- Why strict Decimal types are enforced (financial precision, fail-fast)
- Where validation happens (constructors, public methods)
- How the API layer handles type conversion (Pydantic)

Resolves #47