### PR TITLE
Add database roundtrip test for Decimal types

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -28,3 +28,19 @@ def test_account_mapper_saves_account(session, acc_eur):
     rows = session.execute(select(Account)).scalars().all()
     assert len(rows) == 1
     assert rows[0] == acc_eur
+
+
+def test_decimal_survives_database_roundtrip(session):
+    """Verify SQLAlchemy returns proper Decimal objects after database persistence roundtrip."""
+    # 1. Arrange: Create an Account with a Decimal initial_balance
+    acc = Account(None, "Test", "EUR", Decimal("100.50"))
+    session.add(acc)
+    session.commit()
+
+    # 2. Act: Expunge and reload the Account from database
+    session.expunge_all()
+    loaded = session.execute(select(Account)).scalars().first()
+
+    # 3. Assert: Verify the reloaded initial_balance is a Decimal instance with correct value
+    assert isinstance(loaded.initial_balance, Decimal)
+    assert loaded.initial_balance == Decimal("100.50")


### PR DESCRIPTION
- Add test_decimal_survives_database_roundtrip to tests/test_db.py
- Verifies SQLAlchemy returns proper Decimal objects after persistence
- Tests create, commit, expunge, and reload cycle
- Ensures initial_balance maintains Decimal type and value

Fixes #44