### PR TITLE
feat: add Settings domain, repository, and service layer

### DIFF
--- a/backend/alembic/versions/0002_add_settings_table.py
+++ b/backend/alembic/versions/0002_add_settings_table.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
             "primary_currency",
             sa.String(3),
             nullable=False,
-            server_default="EUR",
+            server_default=sa.text("'EUR'"),
         ),
     )
 

--- a/backend/alembic/versions/0002_add_settings_table.py
+++ b/backend/alembic/versions/0002_add_settings_table.py
@@ -1,0 +1,35 @@
+"""add settings table
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-03-17 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "settings",
+        sa.Column("settings_id", sa.String(36), primary_key=True),
+        sa.Column(
+            "primary_currency",
+            sa.String(3),
+            nullable=False,
+            server_default="EUR",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("settings")

--- a/backend/app/adapters/orm.py
+++ b/backend/app/adapters/orm.py
@@ -62,6 +62,14 @@ transfers = Table(
 )
 
 
+settings = Table(
+    "settings",
+    metadata,
+    Column("settings_id", String(36), primary_key=True),
+    Column("primary_currency", String(3), nullable=False, server_default="EUR"),
+)
+
+
 def start_mappers():
     mapper_registry.map_imperatively(
         model.Account,
@@ -98,3 +106,4 @@ def start_mappers():
     )
     mapper_registry.map_imperatively(model.Posting, postings)
     mapper_registry.map_imperatively(model.Transfer, transfers)
+    mapper_registry.map_imperatively(model.Settings, settings)

--- a/backend/app/adapters/orm.py
+++ b/backend/app/adapters/orm.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Table, Column, ForeignKey, UniqueConstraint, Index
-from sqlalchemy import Boolean, String, Numeric, Date
+from sqlalchemy import Boolean, String, Numeric, Date, text
 from sqlalchemy.orm import registry, relationship, backref
 
 from app.domain import model
@@ -66,7 +66,7 @@ settings = Table(
     "settings",
     metadata,
     Column("settings_id", String(36), primary_key=True),
-    Column("primary_currency", String(3), nullable=False, server_default="EUR"),
+    Column("primary_currency", String(3), nullable=False, server_default=text("'EUR'")),
 )
 
 
@@ -106,4 +106,10 @@ def start_mappers():
     )
     mapper_registry.map_imperatively(model.Posting, postings)
     mapper_registry.map_imperatively(model.Transfer, transfers)
-    mapper_registry.map_imperatively(model.Settings, settings)
+    mapper_registry.map_imperatively(
+        model.Settings,
+        settings,
+        properties={
+            "_primary_currency": settings.c.primary_currency,
+        },
+    )

--- a/backend/app/adapters/settings_repository.py
+++ b/backend/app/adapters/settings_repository.py
@@ -1,0 +1,15 @@
+from sqlalchemy.orm import Session
+
+from app.domain.model import Settings
+from app.service_layer.abstract_settings_repository import AbstractSettingsRepository
+
+
+class SqlAlchemySettingsRepository(AbstractSettingsRepository):
+    def __init__(self, session: Session):
+        self.session = session
+
+    def get(self) -> Settings | None:
+        return self.session.get(Settings, Settings.SINGLETON_ID)
+
+    def save(self, settings: Settings) -> None:
+        self.session.merge(settings)

--- a/backend/app/adapters/unit_of_work.py
+++ b/backend/app/adapters/unit_of_work.py
@@ -4,6 +4,7 @@ from app.adapters.account_repository import SqlAlchemyAccountRepository
 from app.adapters.transfer_repository import SqlAlchemyTransferRepository
 from app.adapters.category_repository import SqlAlchemyCategoryRepository
 from app.adapters.report_repository import SqlAlchemyReportRepository
+from app.adapters.settings_repository import SqlAlchemySettingsRepository
 from app.service_layer.unit_of_work import AbstractUnitOfWork
 
 
@@ -13,6 +14,7 @@ class SqlAlchemyUnitOfWork(AbstractUnitOfWork):
         self.transfers = SqlAlchemyTransferRepository(session)
         self.categories = SqlAlchemyCategoryRepository(session)
         self.reports = SqlAlchemyReportRepository(session)
+        self.settings = SqlAlchemySettingsRepository(session)
         self._session = session
 
     def commit(self):

--- a/backend/app/domain/model.py
+++ b/backend/app/domain/model.py
@@ -196,10 +196,18 @@ class Settings:
         settings_id: str | None = None,
         primary_currency: str = "EUR",
     ):
-        if primary_currency not in VALID_CURRENCIES:
-            raise InvalidCurrencyError(f"Invalid currency: {primary_currency}")
         self.settings_id = settings_id or self.SINGLETON_ID
-        self.primary_currency = primary_currency
+        self.primary_currency = primary_currency  # uses setter validation
+
+    @property
+    def primary_currency(self) -> str:
+        return self._primary_currency
+
+    @primary_currency.setter
+    def primary_currency(self, value: str) -> None:
+        if value not in VALID_CURRENCIES:
+            raise InvalidCurrencyError(f"Invalid currency: {value}")
+        self._primary_currency = value
 
     def __repr__(self) -> str:
         return f"Settings({self.settings_id!r}, {self.primary_currency!r})"

--- a/backend/app/domain/model.py
+++ b/backend/app/domain/model.py
@@ -186,6 +186,33 @@ class Posting:
         return self.posting_date < other.posting_date
 
 
+class Settings:
+    """Application-wide settings singleton."""
+
+    SINGLETON_ID = "default"
+
+    def __init__(
+        self,
+        settings_id: str | None = None,
+        primary_currency: str = "EUR",
+    ):
+        if primary_currency not in VALID_CURRENCIES:
+            raise InvalidCurrencyError(f"Invalid currency: {primary_currency}")
+        self.settings_id = settings_id or self.SINGLETON_ID
+        self.primary_currency = primary_currency
+
+    def __repr__(self) -> str:
+        return f"Settings({self.settings_id!r}, {self.primary_currency!r})"
+
+    def __eq__(self, other):
+        if not isinstance(other, Settings):
+            return False
+        return self.settings_id == other.settings_id
+
+    def __hash__(self):
+        return hash(self.settings_id)
+
+
 class Account:
     def __init__(
         self,

--- a/backend/app/service_layer/abstract_settings_repository.py
+++ b/backend/app/service_layer/abstract_settings_repository.py
@@ -1,0 +1,13 @@
+import abc
+
+from app.domain.model import Settings
+
+
+class AbstractSettingsRepository(abc.ABC):
+    @abc.abstractmethod
+    def get(self) -> Settings | None:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def save(self, settings: Settings) -> None:
+        raise NotImplementedError()

--- a/backend/app/service_layer/services.py
+++ b/backend/app/service_layer/services.py
@@ -10,7 +10,6 @@ from app.domain.exceptions import CategoryInUseError
 from app.domain.exceptions import CategoryNotFoundError
 from app.domain.exceptions import DuplicateAccountNameError
 from app.domain.exceptions import DuplicateCategoryNameError
-from app.domain.exceptions import InvalidCurrencyError
 from app.domain.exceptions import InvalidInitialBalanceError
 from app.domain.exceptions import ParentCategoryPostingError
 from app.domain.exceptions import PostingNotFoundError
@@ -22,7 +21,6 @@ from app.domain.model import Posting
 from app.domain.model import PostingType
 from app.domain.model import Settings
 from app.domain.model import Transfer
-from app.domain.model import VALID_CURRENCIES
 from app.service_layer.unit_of_work import AbstractUnitOfWork
 from app.core.logging_config import get_logger
 
@@ -575,8 +573,6 @@ def update_settings(uow: AbstractUnitOfWork, *, primary_currency: str) -> Settin
         if settings is None:
             settings = Settings(primary_currency=primary_currency)
         else:
-            if primary_currency not in VALID_CURRENCIES:
-                raise InvalidCurrencyError(f"Invalid currency: {primary_currency}")
             settings.primary_currency = primary_currency
         uow.settings.save(settings)
         uow.commit()

--- a/backend/app/service_layer/services.py
+++ b/backend/app/service_layer/services.py
@@ -10,6 +10,7 @@ from app.domain.exceptions import CategoryInUseError
 from app.domain.exceptions import CategoryNotFoundError
 from app.domain.exceptions import DuplicateAccountNameError
 from app.domain.exceptions import DuplicateCategoryNameError
+from app.domain.exceptions import InvalidCurrencyError
 from app.domain.exceptions import InvalidInitialBalanceError
 from app.domain.exceptions import ParentCategoryPostingError
 from app.domain.exceptions import PostingNotFoundError
@@ -19,7 +20,9 @@ from app.domain.model import Category
 from app.domain.model import CategoryType
 from app.domain.model import Posting
 from app.domain.model import PostingType
+from app.domain.model import Settings
 from app.domain.model import Transfer
+from app.domain.model import VALID_CURRENCIES
 from app.service_layer.unit_of_work import AbstractUnitOfWork
 from app.core.logging_config import get_logger
 
@@ -554,3 +557,27 @@ def delete_transfer(uow: AbstractUnitOfWork, *, transfer_id: str) -> None:
         uow.transfers.delete(transfer)
         uow.commit()
         logger.info("Deleted transfer id: %s", transfer_id)
+
+
+def get_settings(uow: AbstractUnitOfWork) -> Settings:
+    with uow:
+        settings = uow.settings.get()
+        if settings is None:
+            settings = Settings()
+            uow.settings.save(settings)
+            uow.commit()
+        return settings
+
+
+def update_settings(uow: AbstractUnitOfWork, *, primary_currency: str) -> Settings:
+    with uow:
+        settings = uow.settings.get()
+        if settings is None:
+            settings = Settings(primary_currency=primary_currency)
+        else:
+            if primary_currency not in VALID_CURRENCIES:
+                raise InvalidCurrencyError(f"Invalid currency: {primary_currency}")
+            settings.primary_currency = primary_currency
+        uow.settings.save(settings)
+        uow.commit()
+        return settings

--- a/backend/app/service_layer/unit_of_work.py
+++ b/backend/app/service_layer/unit_of_work.py
@@ -4,6 +4,7 @@ from app.service_layer.abstract_account_repository import AbstractAccountReposit
 from app.service_layer.abstract_transfer_repository import AbstractTransferRepository
 from app.service_layer.abstract_category_repository import AbstractCategoryRepository
 from app.service_layer.abstract_report_repository import AbstractReportRepository
+from app.service_layer.abstract_settings_repository import AbstractSettingsRepository
 
 
 class AbstractUnitOfWork(abc.ABC):
@@ -11,6 +12,7 @@ class AbstractUnitOfWork(abc.ABC):
     transfers: AbstractTransferRepository
     categories: AbstractCategoryRepository
     reports: AbstractReportRepository
+    settings: AbstractSettingsRepository
 
     def __enter__(self):
         return self

--- a/backend/tests/integration/test_repository.py
+++ b/backend/tests/integration/test_repository.py
@@ -436,3 +436,39 @@ def test_category_count_postings(session):
 
     assert category_repo.count_postings("cat-1") == 2
     assert category_repo.count_postings("nonexistent") == 0
+
+
+def test_settings_save_and_get(session):
+    from app.adapters.settings_repository import SqlAlchemySettingsRepository
+    from app.domain.model import Settings
+
+    repo = SqlAlchemySettingsRepository(session)
+    settings = Settings(settings_id="default", primary_currency="USD")
+    repo.save(settings)
+    session.commit()
+
+    retrieved = repo.get()
+    assert retrieved is not None
+    assert retrieved.settings_id == "default"
+    assert retrieved.primary_currency == "USD"
+
+
+def test_settings_upsert(session):
+    from app.adapters.settings_repository import SqlAlchemySettingsRepository
+    from app.domain.model import Settings
+
+    repo = SqlAlchemySettingsRepository(session)
+
+    # First save
+    settings = Settings(settings_id="default", primary_currency="EUR")
+    repo.save(settings)
+    session.commit()
+
+    # Upsert with different currency
+    settings2 = Settings(settings_id="default", primary_currency="GBP")
+    repo.save(settings2)
+    session.commit()
+
+    retrieved = repo.get()
+    assert retrieved is not None
+    assert retrieved.primary_currency == "GBP"

--- a/backend/tests/unit/test_services.py
+++ b/backend/tests/unit/test_services.py
@@ -7,6 +7,7 @@ from app.domain.model import Transfer
 from app.domain.model import PostingType
 from app.domain.model import CategoryType
 from app.domain.model import Category
+from app.domain.model import Settings
 from app.domain.exceptions import DuplicateAccountNameError
 from app.domain.exceptions import InvalidInitialBalanceError
 from app.domain.exceptions import AccountNotFoundError
@@ -19,6 +20,7 @@ from app.domain.exceptions import DuplicateCategoryNameError
 from app.domain.exceptions import InsufficientFundsError
 from app.domain.exceptions import ParentCategoryPostingError
 from app.domain.exceptions import PostingNotFoundError
+from app.domain.exceptions import InvalidCurrencyError
 from app.domain.exceptions import TransferNotFoundError
 
 from collections.abc import Callable
@@ -27,6 +29,7 @@ from app.service_layer.abstract_account_repository import AbstractAccountReposit
 from app.service_layer.abstract_transfer_repository import AbstractTransferRepository
 from app.service_layer.abstract_category_repository import AbstractCategoryRepository
 from app.service_layer.abstract_report_repository import AbstractReportRepository
+from app.service_layer.abstract_settings_repository import AbstractSettingsRepository
 from app.service_layer.reports import SpendingReport
 from app.service_layer.unit_of_work import AbstractUnitOfWork
 from app.service_layer.services import create_account
@@ -46,6 +49,8 @@ from app.service_layer.services import create_transfer
 from app.service_layer.services import delete_transfer
 from app.service_layer.services import get_transfer
 from app.service_layer.services import list_transfers
+from app.service_layer.services import get_settings
+from app.service_layer.services import update_settings
 from tests.constants import JAN_01
 
 
@@ -151,16 +156,29 @@ class FakeReportRepository(AbstractReportRepository):
         return SpendingReport(period="month", start_date=start_date, end_date=end_date, rows=[])
 
 
+class FakeSettingsRepository(AbstractSettingsRepository):
+    def __init__(self):
+        self._settings: Settings | None = None
+
+    def get(self) -> Settings | None:
+        return self._settings
+
+    def save(self, settings: Settings) -> None:
+        self._settings = settings
+
+
 class FakeUnitOfWork(AbstractUnitOfWork):
     accounts: FakeAccountRepository
     transfers: FakeTransferRepository
     categories: FakeCategoryRepository
     reports: FakeReportRepository
+    settings: FakeSettingsRepository
 
     def __init__(self):
         self.accounts = FakeAccountRepository()
         self.transfers = FakeTransferRepository()
         self.reports = FakeReportRepository()
+        self.settings = FakeSettingsRepository()
         self.committed = False
 
         # Wire up category's count_postings to scan accounts
@@ -1665,3 +1683,40 @@ class TestDeleteTransfer:
             delete_transfer(uow, transfer_id="nonexistent")
         assert "Transfer with id 'nonexistent' not found" in str(exc_info.value)
         assert uow.committed is False
+
+
+class TestSettings:
+    def test_get_settings_returns_default_when_none(self):
+        uow = FakeUnitOfWork()
+        settings = get_settings(uow)
+        assert settings.settings_id == "default"
+        assert settings.primary_currency == "EUR"
+        assert uow.committed is True
+
+    def test_get_settings_returns_existing(self):
+        uow = FakeUnitOfWork()
+        existing = Settings(settings_id="default", primary_currency="USD")
+        uow.settings._settings = existing
+        settings = get_settings(uow)
+        assert settings.primary_currency == "USD"
+        assert settings is existing
+
+    def test_update_settings_changes_currency(self):
+        uow = FakeUnitOfWork()
+        settings = update_settings(uow, primary_currency="GBP")
+        assert settings.primary_currency == "GBP"
+        assert uow.committed is True
+
+    def test_update_settings_overwrites_existing(self):
+        uow = FakeUnitOfWork()
+        existing = Settings(settings_id="default", primary_currency="USD")
+        uow.settings._settings = existing
+        settings = update_settings(uow, primary_currency="JPY")
+        assert settings.primary_currency == "JPY"
+        assert uow.settings._settings.primary_currency == "JPY"
+        assert uow.committed is True
+
+    def test_update_settings_invalid_currency(self):
+        uow = FakeUnitOfWork()
+        with pytest.raises(InvalidCurrencyError):
+            update_settings(uow, primary_currency="XXX")

--- a/backend/tests/unit/test_services.py
+++ b/backend/tests/unit/test_services.py
@@ -1720,3 +1720,10 @@ class TestSettings:
         uow = FakeUnitOfWork()
         with pytest.raises(InvalidCurrencyError):
             update_settings(uow, primary_currency="XXX")
+
+    def test_settings_rejects_invalid_currency_on_mutation(self):
+        settings = Settings(primary_currency="EUR")
+        with pytest.raises(InvalidCurrencyError):
+            settings.primary_currency = "INVALID"
+        # Original value unchanged
+        assert settings.primary_currency == "EUR"


### PR DESCRIPTION
## Summary
- Add `Settings` domain model with singleton pattern (`SINGLETON_ID="default"`) and currency validation against `VALID_CURRENCIES`
- Add `AbstractSettingsRepository` and `SqlAlchemySettingsRepository` with `get()` / `save()` (uses `session.merge` for upsert)
- Wire `settings` repository into `AbstractUnitOfWork` and `SqlAlchemyUnitOfWork`
- Add `get_settings` and `update_settings` service functions with get-or-create logic
- Add ORM `settings` table mapping and Alembic migration `0002_add_settings_table`

## Test plan
- [x] Unit tests (5): default creation, existing retrieval, currency update, overwrite existing, invalid currency rejection
- [x] Integration tests (2): save/get round-trip, upsert behavior
- [x] All 364 existing tests still pass

Implements bt-lho