### PR TITLE
feat: add Spending Timeline data pipeline

### DIFF
--- a/backend/app/adapters/report_repository.py
+++ b/backend/app/adapters/report_repository.py
@@ -65,3 +65,29 @@ class SqlAlchemyReportRepository(AbstractReportRepository):
             end_date=end_date,
             rows=rows,
         )
+
+    def daily_spending(
+        self,
+        start_date: date,
+        end_date: date,
+        currency: str,
+        exclude_savings: bool = True,
+    ) -> list[tuple[date, Decimal]]:
+        stmt = (
+            select(
+                postings.c.posting_date,
+                func.sum(func.abs(postings.c.amount)).label("daily_total"),
+            )
+            .select_from(postings)
+            .join(accounts, postings.c.account_id == accounts.c.account_id)
+            .where(postings.c.posting_type == "EXPENSE")
+            .where(postings.c.posting_date.between(start_date, end_date))
+            .where(accounts.c.currency == currency)
+            .where(accounts.c.is_savings.is_(False) if exclude_savings else True)
+            .group_by(postings.c.posting_date)
+            .order_by(postings.c.posting_date)
+        )
+
+        return [
+            (row.posting_date, Decimal(str(row.daily_total))) for row in self._session.execute(stmt)
+        ]

--- a/backend/app/domain/model.py
+++ b/backend/app/domain/model.py
@@ -186,6 +186,33 @@ class Posting:
         return self.posting_date < other.posting_date
 
 
+class Settings:
+    """Application-wide settings singleton."""
+
+    SINGLETON_ID = "default"
+
+    def __init__(
+        self,
+        settings_id: str | None = None,
+        primary_currency: str = "EUR",
+    ):
+        if primary_currency not in VALID_CURRENCIES:
+            raise InvalidCurrencyError(f"Invalid currency: {primary_currency}")
+        self.settings_id = settings_id or self.SINGLETON_ID
+        self.primary_currency = primary_currency
+
+    def __repr__(self) -> str:
+        return f"Settings({self.settings_id!r}, {self.primary_currency!r})"
+
+    def __eq__(self, other):
+        if not isinstance(other, Settings):
+            return False
+        return self.settings_id == other.settings_id
+
+    def __hash__(self):
+        return hash(self.settings_id)
+
+
 class Account:
     def __init__(
         self,

--- a/backend/app/service_layer/abstract_report_repository.py
+++ b/backend/app/service_layer/abstract_report_repository.py
@@ -1,5 +1,6 @@
 import abc
 from datetime import date
+from decimal import Decimal
 
 from app.service_layer.reports import SpendingReport
 
@@ -12,4 +13,14 @@ class AbstractReportRepository(abc.ABC):
         end_date: date,
         exclude_savings: bool = True,
     ) -> SpendingReport:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def daily_spending(
+        self,
+        start_date: date,
+        end_date: date,
+        currency: str,
+        exclude_savings: bool = True,
+    ) -> list[tuple[date, Decimal]]:
         raise NotImplementedError()

--- a/backend/app/service_layer/reports.py
+++ b/backend/app/service_layer/reports.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING
@@ -25,6 +25,22 @@ class SpendingReport:
     rows: list[CategorySpendingRow]
 
 
+@dataclass
+class DailySpendingRow:
+    spending_date: date
+    daily_total: Decimal
+    cumulative_total: Decimal
+
+
+@dataclass
+class SpendingTimelineReport:
+    start_date: date
+    end_date: date
+    currency: str
+    current_period: list[DailySpendingRow] = field(default_factory=list)
+    previous_period: list[DailySpendingRow] = field(default_factory=list)
+
+
 def _compute_period_dates(period: str, reference: date) -> tuple[date, date]:
     if period == "week":
         start = reference - timedelta(days=reference.weekday())  # Monday
@@ -37,6 +53,32 @@ def _compute_period_dates(period: str, reference: date) -> tuple[date, date]:
         return reference.replace(month=1, day=1), reference.replace(month=12, day=31)
     else:
         raise ValueError(f"Invalid period: {period!r}. Must be 'week', 'month', or 'year'")
+
+
+def _previous_month_range(reference: date) -> tuple[date, date]:
+    """Return (start, end) for the calendar month before reference."""
+    first_of_current = reference.replace(day=1)
+    last_of_prev = first_of_current - timedelta(days=1)
+    first_of_prev = last_of_prev.replace(day=1)
+    return first_of_prev, last_of_prev
+
+
+def _build_cumulative(
+    daily_rows: list[tuple[date, Decimal]],
+) -> list[DailySpendingRow]:
+    """Convert (date, daily_total) pairs into DailySpendingRow with running cumulative total."""
+    result: list[DailySpendingRow] = []
+    running = Decimal("0")
+    for spending_date, daily_total in daily_rows:
+        running += daily_total
+        result.append(
+            DailySpendingRow(
+                spending_date=spending_date,
+                daily_total=daily_total,
+                cumulative_total=running,
+            )
+        )
+    return result
 
 
 def get_spending_report(
@@ -52,3 +94,31 @@ def get_spending_report(
         report = uow.reports.spending_by_period(start, end, exclude_savings=exclude_savings)
         report.period = period
         return report
+
+
+def get_spending_timeline(
+    uow: AbstractUnitOfWork,
+    *,
+    currency: str,
+    exclude_savings: bool = True,
+    reference_date: date | None = None,
+) -> SpendingTimelineReport:
+    ref = reference_date or date.today()
+    current_start, current_end = _compute_period_dates("month", ref)
+    prev_start, prev_end = _previous_month_range(ref)
+
+    with uow:
+        current_rows = uow.reports.daily_spending(
+            current_start, current_end, currency, exclude_savings=exclude_savings
+        )
+        prev_rows = uow.reports.daily_spending(
+            prev_start, prev_end, currency, exclude_savings=exclude_savings
+        )
+
+    return SpendingTimelineReport(
+        start_date=current_start,
+        end_date=current_end,
+        currency=currency,
+        current_period=_build_cumulative(current_rows),
+        previous_period=_build_cumulative(prev_rows),
+    )

--- a/backend/tests/integration/test_repository.py
+++ b/backend/tests/integration/test_repository.py
@@ -5,6 +5,7 @@ from datetime import date
 from app.adapters.account_repository import SqlAlchemyAccountRepository
 from app.adapters.transfer_repository import SqlAlchemyTransferRepository
 from app.adapters.category_repository import SqlAlchemyCategoryRepository
+from app.adapters.report_repository import SqlAlchemyReportRepository
 from app.domain.model import Account, CategoryType, PostingType, Category, Transfer
 from tests.constants import JAN_01
 
@@ -436,3 +437,89 @@ def test_category_count_postings(session):
 
     assert category_repo.count_postings("cat-1") == 2
     assert category_repo.count_postings("nonexistent") == 0
+
+
+def test_daily_spending_groups_by_date(session):
+    """Two postings on the same day are summed; postings on different days are separate rows."""
+    session.execute(
+        text(
+            "INSERT INTO account (account_id, name, currency, initial_balance, is_savings)"
+            " VALUES ('ds-a1', 'EUR Account', 'EUR', 1000, false)"
+        )
+    )
+    session.execute(
+        text(
+            "INSERT INTO posting"
+            " (posting_id, account_id, amount, posting_date, category_id, posting_type)"
+            " VALUES"
+            " ('ds-p1', 'ds-a1', -30, '2026-03-05', NULL, 'EXPENSE'),"
+            " ('ds-p2', 'ds-a1', -20, '2026-03-05', NULL, 'EXPENSE'),"
+            " ('ds-p3', 'ds-a1', -50, '2026-03-10', NULL, 'EXPENSE')"
+        )
+    )
+    session.commit()
+
+    repo = SqlAlchemyReportRepository(session)
+    rows = repo.daily_spending(date(2026, 3, 1), date(2026, 3, 31), "EUR")
+
+    assert len(rows) == 2
+    assert rows[0] == (date(2026, 3, 5), Decimal("50"))
+    assert rows[1] == (date(2026, 3, 10), Decimal("50"))
+
+
+def test_daily_spending_excludes_income(session):
+    """Income postings are not included in daily_spending results."""
+    session.execute(
+        text(
+            "INSERT INTO account (account_id, name, currency, initial_balance, is_savings)"
+            " VALUES ('ds-a2', 'EUR Account 2', 'EUR', 1000, false)"
+        )
+    )
+    session.execute(
+        text(
+            "INSERT INTO posting"
+            " (posting_id, account_id, amount, posting_date, category_id, posting_type)"
+            " VALUES"
+            " ('ds-p4', 'ds-a2', -40, '2026-03-07', NULL, 'EXPENSE'),"
+            " ('ds-p5', 'ds-a2', 200, '2026-03-07', NULL, 'INCOME')"
+        )
+    )
+    session.commit()
+
+    repo = SqlAlchemyReportRepository(session)
+    rows = repo.daily_spending(date(2026, 3, 1), date(2026, 3, 31), "EUR")
+
+    assert len(rows) == 1
+    assert rows[0] == (date(2026, 3, 7), Decimal("40"))
+
+
+def test_daily_spending_filters_by_currency(session):
+    """Only postings from accounts matching the given currency are included."""
+    session.execute(
+        text(
+            "INSERT INTO account (account_id, name, currency, initial_balance, is_savings)"
+            " VALUES"
+            " ('ds-a3', 'EUR Acc', 'EUR', 500, false),"
+            " ('ds-a4', 'USD Acc', 'USD', 500, false)"
+        )
+    )
+    session.execute(
+        text(
+            "INSERT INTO posting"
+            " (posting_id, account_id, amount, posting_date, category_id, posting_type)"
+            " VALUES"
+            " ('ds-p6', 'ds-a3', -60, '2026-03-12', NULL, 'EXPENSE'),"
+            " ('ds-p7', 'ds-a4', -80, '2026-03-12', NULL, 'EXPENSE')"
+        )
+    )
+    session.commit()
+
+    repo = SqlAlchemyReportRepository(session)
+    eur_rows = repo.daily_spending(date(2026, 3, 1), date(2026, 3, 31), "EUR")
+    usd_rows = repo.daily_spending(date(2026, 3, 1), date(2026, 3, 31), "USD")
+
+    assert len(eur_rows) == 1
+    assert eur_rows[0] == (date(2026, 3, 12), Decimal("60"))
+
+    assert len(usd_rows) == 1
+    assert usd_rows[0] == (date(2026, 3, 12), Decimal("80"))

--- a/backend/tests/unit/test_reports.py
+++ b/backend/tests/unit/test_reports.py
@@ -6,8 +6,11 @@ from typing import Any
 from app.service_layer.reports import (
     _compute_period_dates,
     get_spending_report,
+    get_spending_timeline,
     SpendingReport,
     CategorySpendingRow,
+    DailySpendingRow,
+    SpendingTimelineReport,
 )
 from app.service_layer.abstract_report_repository import AbstractReportRepository
 from tests.unit.test_services import FakeUnitOfWork
@@ -67,9 +70,11 @@ class TestPeriodDates:
 class SpyReportRepository(AbstractReportRepository):
     called_with: Any
 
-    def __init__(self, rows=None):
+    def __init__(self, rows=None, daily_rows=None):
         self._rows = rows or []
+        self._daily_rows = daily_rows or []
         self.called_with = None
+        self.daily_spending_calls: list[tuple] = []
 
     def spending_by_period(
         self, start_date: date, end_date: date, exclude_savings: bool = True
@@ -81,6 +86,16 @@ class SpyReportRepository(AbstractReportRepository):
             end_date=end_date,
             rows=self._rows,
         )
+
+    def daily_spending(
+        self,
+        start_date: date,
+        end_date: date,
+        currency: str,
+        exclude_savings: bool = True,
+    ) -> list[tuple[date, Decimal]]:
+        self.daily_spending_calls.append((start_date, end_date, currency, exclude_savings))
+        return self._daily_rows
 
 
 class FakeUnitOfWorkWithReports(FakeUnitOfWork):
@@ -142,3 +157,96 @@ class TestGetSpendingReport:
 
         with pytest.raises(ValueError, match="Invalid period"):
             get_spending_report(uow, period="quarter", reference_date=date(2026, 3, 1))
+
+
+class FakeUnitOfWorkWithTimeline(FakeUnitOfWork):
+    reports: SpyReportRepository
+
+    def __init__(self, daily_rows=None):
+        super().__init__()
+        self.reports = SpyReportRepository(daily_rows=daily_rows)
+
+
+class TestSpendingTimeline:
+    def test_delegates_to_repo(self):
+        """get_spending_timeline calls daily_spending with correct date range and currency."""
+        uow = FakeUnitOfWorkWithTimeline()
+
+        result = get_spending_timeline(uow, currency="EUR", reference_date=date(2026, 3, 15))
+
+        assert isinstance(result, SpendingTimelineReport)
+        assert result.currency == "EUR"
+        # Current period: March 2026
+        assert result.start_date == date(2026, 3, 1)
+        assert result.end_date == date(2026, 3, 31)
+
+    def test_computes_cumulative_totals(self):
+        """Daily totals [10, 20, 30] should produce cumulative [10, 30, 60]."""
+        daily_rows = [
+            (date(2026, 3, 1), Decimal("10")),
+            (date(2026, 3, 2), Decimal("20")),
+            (date(2026, 3, 3), Decimal("30")),
+        ]
+        uow = FakeUnitOfWorkWithTimeline(daily_rows=daily_rows)
+
+        result = get_spending_timeline(uow, currency="EUR", reference_date=date(2026, 3, 15))
+
+        assert len(result.current_period) == 3
+        assert result.current_period[0] == DailySpendingRow(
+            spending_date=date(2026, 3, 1),
+            daily_total=Decimal("10"),
+            cumulative_total=Decimal("10"),
+        )
+        assert result.current_period[1] == DailySpendingRow(
+            spending_date=date(2026, 3, 2),
+            daily_total=Decimal("20"),
+            cumulative_total=Decimal("30"),
+        )
+        assert result.current_period[2] == DailySpendingRow(
+            spending_date=date(2026, 3, 3),
+            daily_total=Decimal("30"),
+            cumulative_total=Decimal("60"),
+        )
+
+    def test_fetches_both_periods(self):
+        """daily_spending is called twice: once for current month, once for previous month."""
+        uow = FakeUnitOfWorkWithTimeline()
+
+        get_spending_timeline(uow, currency="EUR", reference_date=date(2026, 3, 15))
+
+        calls = uow.reports.daily_spending_calls
+        assert len(calls) == 2
+
+        # Current period: March 2026
+        current_call = calls[0]
+        assert current_call[0] == date(2026, 3, 1)
+        assert current_call[1] == date(2026, 3, 31)
+        assert current_call[2] == "EUR"
+
+        # Previous period: February 2026
+        prev_call = calls[1]
+        assert prev_call[0] == date(2026, 2, 1)
+        assert prev_call[1] == date(2026, 2, 28)
+        assert prev_call[2] == "EUR"
+
+    def test_fetches_both_periods_january_wraps_to_december(self):
+        """When reference is January, previous month wraps to December of previous year."""
+        uow = FakeUnitOfWorkWithTimeline()
+
+        get_spending_timeline(uow, currency="USD", reference_date=date(2026, 1, 10))
+
+        calls = uow.reports.daily_spending_calls
+        assert len(calls) == 2
+
+        prev_call = calls[1]
+        assert prev_call[0] == date(2025, 12, 1)
+        assert prev_call[1] == date(2025, 12, 31)
+
+    def test_empty_data(self):
+        """Empty repo returns empty current_period and previous_period lists."""
+        uow = FakeUnitOfWorkWithTimeline(daily_rows=[])
+
+        result = get_spending_timeline(uow, currency="EUR", reference_date=date(2026, 3, 15))
+
+        assert result.current_period == []
+        assert result.previous_period == []

--- a/backend/tests/unit/test_services.py
+++ b/backend/tests/unit/test_services.py
@@ -150,6 +150,15 @@ class FakeReportRepository(AbstractReportRepository):
     ) -> SpendingReport:
         return SpendingReport(period="month", start_date=start_date, end_date=end_date, rows=[])
 
+    def daily_spending(
+        self,
+        start_date: date,
+        end_date: date,
+        currency: str,
+        exclude_savings: bool = True,
+    ) -> list[tuple[date, Decimal]]:
+        return []
+
 
 class FakeUnitOfWork(AbstractUnitOfWork):
     accounts: FakeAccountRepository


### PR DESCRIPTION
## Summary
- Add `daily_spending()` to report repository (abstract + SQL implementation): groups EXPENSE postings by date, filtered by currency and savings exclusion
- Add `_previous_month_range()` and `_build_cumulative()` helpers to reports service
- Add `DailySpendingRow` and `SpendingTimelineReport` dataclasses
- Add `get_spending_timeline()` service function that fetches current and previous month with cumulative running totals
- Add `Settings` domain class (needed to fix pre-existing typecheck issues from co-developed settings feature)

## Test plan
- [x] Unit tests: repo delegation, cumulative computation ([10,20,30] → [10,30,60]), both periods fetched (current + previous month), January→December year wrap, empty data
- [x] Integration tests: date grouping (2 postings same day summed), income exclusion (only EXPENSE type), currency filter
- [x] All 365 existing tests still pass

Implements bt-30v