### PR TITLE
fix: add dev branch to CI workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, dev]
+  push:
+    branches: [dev]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `dev` to the `pull_request.branches` list so CI runs on PRs targeting dev
- Add `push.branches: [dev]` trigger so CI runs after merges into dev (catches integration issues)
- `deploy.yml` is untouched — deploy still only triggers on push to master

## Test plan
- [ ] This PR itself targets `dev` — CI should run on it (self-verifying)
- [ ] PRs targeting `master` still trigger CI (regression check)
- [ ] `deploy.yml` unchanged

Closes bt-jpd