### PR TITLE
feat: add PreToolUse hook to block PRs targeting master

### DIFF
--- a/.claude/hooks/check-branch-base.sh
+++ b/.claude/hooks/check-branch-base.sh
@@ -25,5 +25,5 @@ echo "BLOCKED: Do not use 'git checkout -b' directly."
 echo ""
 echo "  Use:  make branch name=fix/my-feature"
 echo ""
-echo "  This fetches origin and branches from origin/master automatically."
+echo "  This fetches origin and branches from origin/dev automatically."
 exit 2

--- a/.claude/hooks/check-pr-target.sh
+++ b/.claude/hooks/check-pr-target.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook: block PRs that target master.
+# All feature PRs must target 'dev'. Only dev->master release PRs are allowed
+# (created manually, not by agents).
+#
+# Exit 0 = allow, Exit 2 = block with message on stdout.
+
+set -euo pipefail
+
+# Read the Bash tool input from stdin
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('command',''))" 2>/dev/null || echo "")
+
+# Only inspect gh pr create commands
+if ! echo "$CMD" | grep -qE 'gh pr create'; then
+  exit 0
+fi
+
+# Allow if explicitly targeting dev
+if echo "$CMD" | grep -qE '(--base |--base=|-B )dev\b'; then
+  exit 0
+fi
+
+# Block: either targets master explicitly, or no --base specified
+echo "BLOCKED: PRs must target the 'dev' branch, not 'master'."
+echo ""
+echo "  Use:  gh pr create --base dev ..."
+echo ""
+echo "  The dev branch is the integration branch. Only dev->master PRs trigger production deploys."
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,15 @@
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-branch-base.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-pr-target.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
## Summary
- Add `check-pr-target.sh` hook that blocks `gh pr create` unless `--base dev` is specified
- Update `check-branch-base.sh` message to reference `origin/dev` instead of `origin/master`
- Register new hook in `.claude/settings.json`

## Test plan
- [ ] `gh pr create --base master` → blocked with helpful message
- [ ] `gh pr create --base dev` → allowed
- [ ] `gh pr create` (no --base) → blocked (safe default)
- [ ] `-B dev` / `-B master` shorthand → correctly allowed/blocked
- [ ] Non-PR Bash commands → unaffected

Closes bt-e0j