### PR TITLE
feat: Dashboard Homepage with widgets + Settings page

### DIFF
--- a/backend/app/api/routers/dashboard.py
+++ b/backend/app/api/routers/dashboard.py
@@ -25,11 +25,19 @@ router = APIRouter()
 UoWDep = Annotated[AbstractUnitOfWork, Depends(get_unit_of_work)]
 
 
+_TWO_PLACES = Decimal("0.01")
+
+
+def _round2(value: Decimal) -> Decimal:
+    """Round a Decimal to 2 decimal places (half-up)."""
+    return value.quantize(_TWO_PLACES)
+
+
 def _spending_ratio(spending: Decimal, income: Decimal) -> Decimal | None:
     """spending / income * 100, None if income is zero."""
     if income == 0:
         return None
-    return spending * 100 / income
+    return _round2(spending * 100 / income)
 
 
 @router.get("/dashboard/income-vs-spending", response_model=IncomeVsSpendingResponse)
@@ -109,7 +117,7 @@ def spending_timeline(
         days_in_month = calendar.monthrange(ref.year, ref.month)[1]
         day_of_month = ref.day
         if day_of_month > 0:
-            projected_total = cumulative * days_in_month / day_of_month
+            projected_total = _round2(cumulative * days_in_month / day_of_month)
 
     return SpendingTimelineResponse(
         start_date=timeline.start_date,

--- a/backend/app/api/routers/dashboard.py
+++ b/backend/app/api/routers/dashboard.py
@@ -1,0 +1,135 @@
+"""Dashboard API endpoints: Income vs Spending, Spending by Categories, Spending Timeline."""
+
+import calendar
+from datetime import date
+from decimal import Decimal
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from app.api.dependencies import get_unit_of_work
+from app.api.schemas import (
+    CategorySpendingResponse,
+    DailySpendingResponse,
+    IncomeVsSpendingResponse,
+    SpendingTimelineResponse,
+)
+from app.service_layer.reports import (
+    get_income_vs_spending,
+    get_spending_report,
+    get_spending_timeline,
+)
+from app.service_layer.unit_of_work import AbstractUnitOfWork
+
+router = APIRouter()
+UoWDep = Annotated[AbstractUnitOfWork, Depends(get_unit_of_work)]
+
+
+def _spending_ratio(spending: Decimal, income: Decimal) -> Decimal | None:
+    """spending / income * 100, None if income is zero."""
+    if income == 0:
+        return None
+    return spending * 100 / income
+
+
+@router.get("/dashboard/income-vs-spending", response_model=IncomeVsSpendingResponse)
+def income_vs_spending(
+    uow: UoWDep,
+    currency: str,
+    reference_date: date | None = None,
+    exclude_savings: bool = True,
+):
+    summary = get_income_vs_spending(
+        uow,
+        currency=currency,
+        exclude_savings=exclude_savings,
+        reference_date=reference_date,
+    )
+    return IncomeVsSpendingResponse(
+        start_date=summary.start_date,
+        end_date=summary.end_date,
+        currency=summary.currency,
+        total_income=summary.total_income,
+        total_spending=summary.total_spending,
+        net_income=summary.net_income,
+        prev_total_income=summary.prev_total_income,
+        prev_total_spending=summary.prev_total_spending,
+        spending_ratio=_spending_ratio(summary.total_spending, summary.total_income),
+        prev_spending_ratio=_spending_ratio(summary.prev_total_spending, summary.prev_total_income),
+    )
+
+
+@router.get(
+    "/dashboard/spending-by-categories",
+    response_model=list[CategorySpendingResponse],
+)
+def spending_by_categories(
+    uow: UoWDep,
+    currency: str,
+    reference_date: date | None = None,
+    exclude_savings: bool = True,
+):
+    report = get_spending_report(
+        uow,
+        period="month",
+        exclude_savings=exclude_savings,
+        reference_date=reference_date,
+    )
+    return [
+        CategorySpendingResponse(
+            parent_category_id=row.parent_category_id,
+            parent_category_name=row.parent_category_name,
+            currency=row.currency,
+            total=row.total,
+        )
+        for row in report.rows
+        if row.currency == currency
+    ]
+
+
+@router.get("/dashboard/spending-timeline", response_model=SpendingTimelineResponse)
+def spending_timeline(
+    uow: UoWDep,
+    currency: str,
+    reference_date: date | None = None,
+    exclude_savings: bool = True,
+):
+    ref = reference_date or date.today()
+    timeline = get_spending_timeline(
+        uow,
+        currency=currency,
+        exclude_savings=exclude_savings,
+        reference_date=reference_date,
+    )
+
+    # Compute projected total
+    projected_total: Decimal | None = None
+    if timeline.current_period:
+        cumulative = timeline.current_period[-1].cumulative_total
+        days_in_month = calendar.monthrange(ref.year, ref.month)[1]
+        day_of_month = ref.day
+        if day_of_month > 0:
+            projected_total = cumulative * days_in_month / day_of_month
+
+    return SpendingTimelineResponse(
+        start_date=timeline.start_date,
+        end_date=timeline.end_date,
+        currency=timeline.currency,
+        current_period=[
+            DailySpendingResponse(
+                spending_date=row.spending_date,
+                daily_total=row.daily_total,
+                cumulative_total=row.cumulative_total,
+            )
+            for row in timeline.current_period
+        ],
+        previous_period=[
+            DailySpendingResponse(
+                spending_date=row.spending_date,
+                daily_total=row.daily_total,
+                cumulative_total=row.cumulative_total,
+            )
+            for row in timeline.previous_period
+        ],
+        projected_total=projected_total,
+    )

--- a/backend/app/api/routers/settings.py
+++ b/backend/app/api/routers/settings.py
@@ -1,0 +1,29 @@
+"""Settings API endpoints."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.api.dependencies import get_unit_of_work
+from app.api.schemas import SettingsResponse, UpdateSettingsRequest
+from app.domain.exceptions import InvalidCurrencyError
+from app.service_layer.services import get_settings, update_settings
+from app.service_layer.unit_of_work import AbstractUnitOfWork
+
+router = APIRouter()
+UoWDep = Annotated[AbstractUnitOfWork, Depends(get_unit_of_work)]
+
+
+@router.get("/settings", response_model=SettingsResponse)
+def get_settings_endpoint(uow: UoWDep):
+    settings = get_settings(uow)
+    return SettingsResponse(primary_currency=settings.primary_currency)
+
+
+@router.patch("/settings", response_model=SettingsResponse)
+def update_settings_endpoint(body: UpdateSettingsRequest, uow: UoWDep):
+    try:
+        settings = update_settings(uow, primary_currency=body.primary_currency)
+    except InvalidCurrencyError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    return SettingsResponse(primary_currency=settings.primary_currency)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -190,3 +190,54 @@ class SpendingReportResponse(BaseModel):
     start_date: date
     end_date: date
     rows: list[CategorySpendingResponse]
+
+
+# ── Dashboard ─────────────────────────────────────────────────────
+
+
+class IncomeVsSpendingResponse(BaseModel):
+    start_date: date
+    end_date: date
+    currency: str
+    total_income: Decimal
+    total_spending: Decimal
+    net_income: Decimal
+    prev_total_income: Decimal
+    prev_total_spending: Decimal
+    spending_ratio: Decimal | None
+    prev_spending_ratio: Decimal | None
+
+
+class DailySpendingResponse(BaseModel):
+    spending_date: date
+    daily_total: Decimal
+    cumulative_total: Decimal
+
+
+class SpendingTimelineResponse(BaseModel):
+    start_date: date
+    end_date: date
+    currency: str
+    current_period: list[DailySpendingResponse]
+    previous_period: list[DailySpendingResponse]
+    projected_total: Decimal | None
+
+
+class DashboardCategorySpendingResponse(BaseModel):
+    parent_category_id: str
+    parent_category_name: str
+    currency: str
+    total: Decimal
+
+
+# ── Settings ──────────────────────────────────────────────────────
+
+
+class SettingsResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    primary_currency: str
+
+
+class UpdateSettingsRequest(BaseModel):
+    primary_currency: str

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -223,13 +223,6 @@ class SpendingTimelineResponse(BaseModel):
     projected_total: Decimal | None
 
 
-class DashboardCategorySpendingResponse(BaseModel):
-    parent_category_id: str
-    parent_category_name: str
-    currency: str
-    total: Decimal
-
-
 # ── Settings ──────────────────────────────────────────────────────
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.auth import verify_api_key
 from app.api.middleware import LoggingMiddleware
-from app.api.routers import accounts, categories, postings, reports, transfers
+from app.api.routers import accounts, categories, dashboard, postings, reports, settings, transfers
 from app.core.config import get_cors_origins
 from app.core.db import Database
 from app.core.logging_config import setup_logging
@@ -27,6 +27,8 @@ app.include_router(categories.router, dependencies=[Depends(verify_api_key)])
 app.include_router(postings.router, dependencies=[Depends(verify_api_key)])
 app.include_router(transfers.router, dependencies=[Depends(verify_api_key)])
 app.include_router(reports.router, dependencies=[Depends(verify_api_key)])
+app.include_router(dashboard.router, dependencies=[Depends(verify_api_key)])
+app.include_router(settings.router, dependencies=[Depends(verify_api_key)])
 
 # Add CORS middleware
 app.add_middleware(

--- a/backend/tests/e2e/test_dashboard_api.py
+++ b/backend/tests/e2e/test_dashboard_api.py
@@ -1,0 +1,231 @@
+"""E2E tests for dashboard API endpoints."""
+
+from decimal import Decimal
+from datetime import date
+
+
+def _create_account(client, name, currency="EUR", initial_balance="1000.00", is_savings=False):
+    resp = client.post(
+        "/accounts/",
+        json={
+            "name": name,
+            "currency": currency,
+            "initial_balance": initial_balance,
+            "is_savings": is_savings,
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()["account_id"]
+
+
+def _create_category_hierarchy(client, parent_name, sub_name, category_type="EXPENSE"):
+    parent_resp = client.post(
+        "/categories/",
+        json={"name": parent_name, "category_type": category_type},
+    )
+    assert parent_resp.status_code == 201
+    parent_id = parent_resp.json()["category_id"]
+
+    sub_resp = client.post(
+        "/categories/",
+        json={"name": sub_name, "category_type": category_type, "parent_id": parent_id},
+    )
+    assert sub_resp.status_code == 201
+    sub_id = sub_resp.json()["category_id"]
+
+    return parent_id, sub_id
+
+
+def _create_posting(
+    client, account_id, amount, posting_date, posting_type="EXPENSE", category_id=None
+):
+    payload = {
+        "account_id": account_id,
+        "amount": str(amount),
+        "posting_date": posting_date.isoformat()
+        if isinstance(posting_date, date)
+        else posting_date,
+        "posting_type": posting_type,
+    }
+    if category_id:
+        payload["category_id"] = category_id
+    resp = client.post("/postings/", json=payload)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+# ── Income vs Spending ────────────────────────────────────────────
+
+
+class TestIncomeVsSpendingUnauthorized:
+    def test_unauthorized_returns_401(self, client_no_auth):
+        response = client_no_auth.get(
+            "/dashboard/income-vs-spending",
+            params={"currency": "EUR", "reference_date": "2026-03-15"},
+        )
+        assert response.status_code == 401
+
+
+class TestIncomeVsSpendingEmpty:
+    def test_income_vs_spending_empty(self, client):
+        """No postings → zeros, ratios null."""
+        response = client.get(
+            "/dashboard/income-vs-spending",
+            params={"currency": "EUR", "reference_date": "2026-03-15"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["currency"] == "EUR"
+        assert Decimal(data["total_income"]) == Decimal("0")
+        assert Decimal(data["total_spending"]) == Decimal("0")
+        assert Decimal(data["net_income"]) == Decimal("0")
+        assert data["spending_ratio"] is None
+
+
+class TestIncomeVsSpendingWithData:
+    def test_income_vs_spending_with_data(self, client):
+        """Create income + expense, verify totals + spending_ratio."""
+        acc_id = _create_account(client, "IvS Data Account")
+        _, inc_sub_id = _create_category_hierarchy(client, "Salary IvS", "Monthly IvS", "INCOME")
+        _, exp_sub_id = _create_category_hierarchy(client, "Food IvS", "Groceries IvS")
+
+        _create_posting(
+            client,
+            acc_id,
+            "2000.00",
+            date(2026, 3, 1),
+            posting_type="INCOME",
+            category_id=inc_sub_id,
+        )
+        _create_posting(
+            client,
+            acc_id,
+            "500.00",
+            date(2026, 3, 10),
+            category_id=exp_sub_id,
+        )
+
+        response = client.get(
+            "/dashboard/income-vs-spending",
+            params={"currency": "EUR", "reference_date": "2026-03-15"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert Decimal(data["total_income"]) == Decimal("2000")
+        assert Decimal(data["total_spending"]) == Decimal("500")
+        assert Decimal(data["net_income"]) == Decimal("1500")
+        # spending_ratio = spending / income * 100 = 500/2000 * 100 = 25
+        assert Decimal(data["spending_ratio"]) == Decimal("25")
+
+
+class TestIncomeVsSpendingMissingCurrency:
+    def test_missing_currency_returns_422(self, client):
+        response = client.get(
+            "/dashboard/income-vs-spending",
+            params={"reference_date": "2026-03-15"},
+        )
+        assert response.status_code == 422
+
+
+# ── Spending by Categories ────────────────────────────────────────
+
+
+class TestSpendingByCategoriesUnauthorized:
+    def test_unauthorized_returns_401(self, client_no_auth):
+        response = client_no_auth.get(
+            "/dashboard/spending-by-categories",
+            params={"currency": "EUR", "reference_date": "2026-03-15"},
+        )
+        assert response.status_code == 401
+
+
+class TestSpendingByCategoriesFiltersCurrency:
+    def test_spending_by_categories_filters_currency(self, client):
+        """EUR only when currency=EUR."""
+        eur_acc_id = _create_account(client, "SbC EUR Account", currency="EUR")
+        usd_acc_id = _create_account(client, "SbC USD Account", currency="USD")
+        _, exp_sub_id = _create_category_hierarchy(client, "Food SbC", "Groceries SbC")
+
+        _create_posting(client, eur_acc_id, "100.00", date(2026, 3, 5), category_id=exp_sub_id)
+        _create_posting(client, usd_acc_id, "200.00", date(2026, 3, 5), category_id=exp_sub_id)
+
+        response = client.get(
+            "/dashboard/spending-by-categories",
+            params={"currency": "EUR", "reference_date": "2026-03-15"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        # Should only contain EUR rows
+        for row in data:
+            assert row["currency"] == "EUR"
+        totals = sum(Decimal(r["total"]) for r in data)
+        assert totals == Decimal("100")
+
+
+class TestSpendingByCategoriesMissingCurrency:
+    def test_missing_currency_returns_422(self, client):
+        response = client.get(
+            "/dashboard/spending-by-categories",
+            params={"reference_date": "2026-03-15"},
+        )
+        assert response.status_code == 422
+
+
+# ── Spending Timeline ─────────────────────────────────────────────
+
+
+class TestSpendingTimelineUnauthorized:
+    def test_unauthorized_returns_401(self, client_no_auth):
+        response = client_no_auth.get(
+            "/dashboard/spending-timeline",
+            params={"currency": "EUR", "reference_date": "2026-03-15"},
+        )
+        assert response.status_code == 401
+
+
+class TestSpendingTimelineCumulative:
+    def test_spending_timeline_cumulative(self, client):
+        """Verify daily spending accumulates correctly."""
+        acc_id = _create_account(client, "Timeline Acc")
+        _create_posting(client, acc_id, "30.00", date(2026, 3, 5))
+        _create_posting(client, acc_id, "20.00", date(2026, 3, 10))
+
+        response = client.get(
+            "/dashboard/spending-timeline",
+            params={"currency": "EUR", "reference_date": "2026-03-15"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        current = data["current_period"]
+        assert len(current) == 2
+        assert Decimal(current[0]["daily_total"]) == Decimal("30")
+        assert Decimal(current[0]["cumulative_total"]) == Decimal("30")
+        assert Decimal(current[1]["daily_total"]) == Decimal("20")
+        assert Decimal(current[1]["cumulative_total"]) == Decimal("50")
+
+
+class TestSpendingTimelineProjection:
+    def test_spending_timeline_projection(self, client):
+        """Verify projected_total is calculated."""
+        acc_id = _create_account(client, "Proj Acc")
+        _create_posting(client, acc_id, "100.00", date(2026, 3, 10))
+
+        response = client.get(
+            "/dashboard/spending-timeline",
+            params={"currency": "EUR", "reference_date": "2026-03-10"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        # projected_total = cumulative * days_in_month / day_of_month
+        # = 100 * 31 / 10 = 310
+        assert data["projected_total"] is not None
+        assert Decimal(data["projected_total"]) == Decimal("310")
+
+
+class TestSpendingTimelineMissingCurrency:
+    def test_missing_currency_returns_422(self, client):
+        response = client.get(
+            "/dashboard/spending-timeline",
+            params={"reference_date": "2026-03-15"},
+        )
+        assert response.status_code == 422

--- a/backend/tests/e2e/test_settings_api.py
+++ b/backend/tests/e2e/test_settings_api.py
@@ -1,0 +1,37 @@
+"""E2E tests for settings API endpoints."""
+
+
+class TestGetSettingsDefaults:
+    def test_get_settings_returns_defaults(self, client):
+        """GET /settings → 200, primary_currency="EUR"."""
+        response = client.get("/settings")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["primary_currency"] == "EUR"
+
+
+class TestUpdateSettings:
+    def test_update_settings(self, client):
+        """PATCH /settings {"primary_currency": "USD"} → 200, verify GET returns USD."""
+        response = client.patch("/settings", json={"primary_currency": "USD"})
+        assert response.status_code == 200
+        assert response.json()["primary_currency"] == "USD"
+
+        # Verify GET returns updated value
+        get_response = client.get("/settings")
+        assert get_response.status_code == 200
+        assert get_response.json()["primary_currency"] == "USD"
+
+
+class TestUpdateSettingsInvalidCurrency:
+    def test_update_settings_invalid_currency_returns_422(self, client):
+        """PATCH with "INVALID" → 422."""
+        response = client.patch("/settings", json={"primary_currency": "INVALID"})
+        assert response.status_code == 422
+
+
+class TestSettingsUnauthorized:
+    def test_unauthorized_returns_401(self, client_no_auth):
+        """client_no_auth GET /settings → 401."""
+        response = client_no_auth.get("/settings")
+        assert response.status_code == 401

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -70,6 +70,11 @@ import type {
   TransferCreate,
   TransferResponse,
   SpendingReportResponse,
+  IncomeVsSpendingResponse,
+  SpendingTimelineResponse,
+  CategorySpendingResponse,
+  SettingsResponse,
+  UpdateSettingsRequest,
 } from "./types";
 
 export async function validateApiKey(key: string): Promise<void> {
@@ -171,5 +176,41 @@ export const api = {
       request<SpendingReportResponse>(
         `/reports/spending${buildQuery(params)}`,
       ),
+  },
+
+  dashboard: {
+    incomeVsSpending: (params: {
+      currency: string;
+      reference_date?: string;
+      exclude_savings?: boolean;
+    }) =>
+      request<IncomeVsSpendingResponse>(
+        `/dashboard/income-vs-spending${buildQuery(params)}`,
+      ),
+    spendingByCategories: (params: {
+      currency: string;
+      reference_date?: string;
+      exclude_savings?: boolean;
+    }) =>
+      request<CategorySpendingResponse[]>(
+        `/dashboard/spending-by-categories${buildQuery(params)}`,
+      ),
+    spendingTimeline: (params: {
+      currency: string;
+      reference_date?: string;
+      exclude_savings?: boolean;
+    }) =>
+      request<SpendingTimelineResponse>(
+        `/dashboard/spending-timeline${buildQuery(params)}`,
+      ),
+  },
+
+  settings: {
+    get: () => request<SettingsResponse>("/settings"),
+    update: (data: UpdateSettingsRequest) =>
+      request<SettingsResponse>("/settings", {
+        method: "PATCH",
+        body: JSON.stringify(data),
+      }),
   },
 };

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -21,6 +21,11 @@ import type {
   TransferCreate,
   TransferResponse,
   SpendingReportResponse,
+  IncomeVsSpendingResponse,
+  SpendingTimelineResponse,
+  CategorySpendingResponse,
+  SettingsResponse,
+  UpdateSettingsRequest,
 } from "./types";
 
 const PAGE_SIZE = 50;
@@ -228,5 +233,89 @@ export function useSpendingReport(
         reference_date: referenceDate,
         exclude_savings: excludeSavings,
       }),
+  });
+}
+
+// --- Dashboard ---
+
+export function useIncomeVsSpending(
+  currency: string,
+  referenceDate?: string,
+  excludeSavings: boolean = true,
+) {
+  return useQuery<IncomeVsSpendingResponse>({
+    queryKey: queryKeys.dashboard.incomeVsSpending(
+      currency,
+      referenceDate,
+      excludeSavings,
+    ),
+    queryFn: () =>
+      api.dashboard.incomeVsSpending({
+        currency,
+        reference_date: referenceDate,
+        exclude_savings: excludeSavings,
+      }),
+    enabled: !!currency,
+  });
+}
+
+export function useSpendingByCategories(
+  currency: string,
+  referenceDate?: string,
+  excludeSavings: boolean = true,
+) {
+  return useQuery<CategorySpendingResponse[]>({
+    queryKey: queryKeys.dashboard.spendingByCategories(
+      currency,
+      referenceDate,
+      excludeSavings,
+    ),
+    queryFn: () =>
+      api.dashboard.spendingByCategories({
+        currency,
+        reference_date: referenceDate,
+        exclude_savings: excludeSavings,
+      }),
+    enabled: !!currency,
+  });
+}
+
+export function useSpendingTimeline(
+  currency: string,
+  referenceDate?: string,
+  excludeSavings: boolean = true,
+) {
+  return useQuery<SpendingTimelineResponse>({
+    queryKey: queryKeys.dashboard.spendingTimeline(
+      currency,
+      referenceDate,
+      excludeSavings,
+    ),
+    queryFn: () =>
+      api.dashboard.spendingTimeline({
+        currency,
+        reference_date: referenceDate,
+        exclude_savings: excludeSavings,
+      }),
+    enabled: !!currency,
+  });
+}
+
+// --- Settings ---
+
+export function useSettings() {
+  return useQuery<SettingsResponse>({
+    queryKey: queryKeys.settings.all,
+    queryFn: () => api.settings.get(),
+  });
+}
+
+export function useUpdateSettings() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: UpdateSettingsRequest) => api.settings.update(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.settings.all });
+    },
   });
 }

--- a/frontend/src/api/keys.ts
+++ b/frontend/src/api/keys.ts
@@ -28,4 +28,39 @@ export const queryKeys = {
     ) =>
       ["reports", "spending", { period, referenceDate, excludeSavings }] as const,
   },
+  dashboard: {
+    incomeVsSpending: (
+      currency: string,
+      referenceDate?: string,
+      excludeSavings: boolean = true,
+    ) =>
+      [
+        "dashboard",
+        "income-vs-spending",
+        { currency, referenceDate, excludeSavings },
+      ] as const,
+    spendingByCategories: (
+      currency: string,
+      referenceDate?: string,
+      excludeSavings: boolean = true,
+    ) =>
+      [
+        "dashboard",
+        "spending-by-categories",
+        { currency, referenceDate, excludeSavings },
+      ] as const,
+    spendingTimeline: (
+      currency: string,
+      referenceDate?: string,
+      excludeSavings: boolean = true,
+    ) =>
+      [
+        "dashboard",
+        "spending-timeline",
+        { currency, referenceDate, excludeSavings },
+      ] as const,
+  },
+  settings: {
+    all: ["settings"] as const,
+  },
 };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -127,6 +127,46 @@ export interface SpendingReportResponse {
   rows: CategorySpendingResponse[];
 }
 
+// --- Dashboard ---
+
+export interface IncomeVsSpendingResponse {
+  start_date: string;
+  end_date: string;
+  currency: string;
+  total_income: string;
+  total_spending: string;
+  net_income: string;
+  prev_total_income: string;
+  prev_total_spending: string;
+  spending_ratio: string | null;
+  prev_spending_ratio: string | null;
+}
+
+export interface DailySpendingEntry {
+  spending_date: string;
+  daily_total: string;
+  cumulative_total: string;
+}
+
+export interface SpendingTimelineResponse {
+  start_date: string;
+  end_date: string;
+  currency: string;
+  current_period: DailySpendingEntry[];
+  previous_period: DailySpendingEntry[];
+  projected_total: string | null;
+}
+
+// --- Settings ---
+
+export interface SettingsResponse {
+  primary_currency: string;
+}
+
+export interface UpdateSettingsRequest {
+  primary_currency: string;
+}
+
 // --- Errors ---
 
 export interface ApiErrorSimple {

--- a/frontend/src/components/dashboard/IncomeVsSpendingWidget.tsx
+++ b/frontend/src/components/dashboard/IncomeVsSpendingWidget.tsx
@@ -10,9 +10,12 @@ interface Props {
 function TrendIndicator({
   current,
   previous,
+  upIsGood = false,
 }: {
   current: string;
   previous: string;
+  /** When true, an increase is colored green (good). Default: false (increase = red = bad, for spending). */
+  upIsGood?: boolean;
 }) {
   const curr = Number(current);
   const prev = Number(previous);
@@ -21,10 +24,12 @@ function TrendIndicator({
   const isUp = pctChange > 0;
   const Icon = pctChange === 0 ? Minus : isUp ? TrendingUp : TrendingDown;
 
+  const isPositive = upIsGood ? isUp : !isUp;
+
   return (
     <span
       className={`inline-flex items-center gap-1 text-xs ${
-        isUp ? "text-red-500" : "text-green-500"
+        isPositive ? "text-green-500" : "text-red-500"
       }`}
     >
       <Icon className="size-3" />
@@ -51,6 +56,7 @@ export function IncomeVsSpendingWidget({ data }: Props) {
           <TrendIndicator
             current={data.total_income}
             previous={data.prev_total_income}
+            upIsGood
           />
         </CardContent>
       </Card>

--- a/frontend/src/components/dashboard/IncomeVsSpendingWidget.tsx
+++ b/frontend/src/components/dashboard/IncomeVsSpendingWidget.tsx
@@ -1,0 +1,96 @@
+import { TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/format";
+import type { IncomeVsSpendingResponse } from "@/api/types";
+
+interface Props {
+  data: IncomeVsSpendingResponse;
+}
+
+function TrendIndicator({
+  current,
+  previous,
+}: {
+  current: string;
+  previous: string;
+}) {
+  const curr = Number(current);
+  const prev = Number(previous);
+  if (prev === 0) return null;
+  const pctChange = ((curr - prev) / prev) * 100;
+  const isUp = pctChange > 0;
+  const Icon = pctChange === 0 ? Minus : isUp ? TrendingUp : TrendingDown;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs ${
+        isUp ? "text-red-500" : "text-green-500"
+      }`}
+    >
+      <Icon className="size-3" />
+      {Math.abs(pctChange).toFixed(0)}% vs prev month
+    </span>
+  );
+}
+
+export function IncomeVsSpendingWidget({ data }: Props) {
+  const netPositive = Number(data.net_income) >= 0;
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            Income
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold text-green-600 dark:text-green-400">
+            {formatCurrency(data.total_income, data.currency)}
+          </p>
+          <TrendIndicator
+            current={data.total_income}
+            previous={data.prev_total_income}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            Spending
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold text-red-600 dark:text-red-400">
+            {formatCurrency(data.total_spending, data.currency)}
+          </p>
+          {data.spending_ratio && (
+            <span className="text-xs text-muted-foreground">
+              {Number(data.spending_ratio).toFixed(0)}% of income
+            </span>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            Net Income
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p
+            className={`text-2xl font-bold ${
+              netPositive
+                ? "text-green-600 dark:text-green-400"
+                : "text-red-600 dark:text-red-400"
+            }`}
+          >
+            {formatCurrency(data.net_income, data.currency)}
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/SpendingByCategoriesWidget.tsx
+++ b/frontend/src/components/dashboard/SpendingByCategoriesWidget.tsx
@@ -1,0 +1,200 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/format";
+import type { CategorySpendingResponse } from "@/api/types";
+
+const COLORS = [
+  "#2563eb",
+  "#dc2626",
+  "#16a34a",
+  "#ea580c",
+  "#9333ea",
+  "#0891b2",
+  "#ca8a04",
+  "#e11d48",
+];
+
+interface Props {
+  rows: CategorySpendingResponse[];
+  currency: string;
+}
+
+interface ChartDataItem {
+  name: string;
+  value: number;
+}
+
+function buildChartData(rows: CategorySpendingResponse[]): ChartDataItem[] {
+  return rows
+    .map((row) => ({
+      name: row.parent_category_name,
+      value: Math.abs(Number(row.total)),
+    }))
+    .sort((a, b) => b.value - a.value);
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: Array<{ value: number; name?: string }>;
+  label?: string;
+  currency: string;
+}
+
+function BarTooltip({ active, payload, label, currency }: CustomTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  return (
+    <div className="rounded-md border bg-background px-3 py-2 text-sm shadow-md">
+      <p className="font-medium">{label}</p>
+      <p className="text-muted-foreground">
+        {formatCurrency(String(payload[0].value), currency)}
+      </p>
+    </div>
+  );
+}
+
+function PieTooltip({ active, payload, currency }: CustomTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  return (
+    <div className="rounded-md border bg-background px-3 py-2 text-sm shadow-md">
+      <p className="font-medium">{payload[0].name}</p>
+      <p className="text-muted-foreground">
+        {formatCurrency(String(payload[0].value), currency)}
+      </p>
+    </div>
+  );
+}
+
+export function SpendingByCategoriesWidget({ rows, currency }: Props) {
+  const chartData = buildChartData(rows);
+  const total = chartData.reduce((sum, item) => sum + item.value, 0);
+  const barHeight = Math.max(200, chartData.length * 44);
+
+  if (chartData.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Spending by Categories</CardTitle>
+        <p className="text-2xl font-bold">
+          {formatCurrency(String(total), currency)}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-6 md:grid-cols-2">
+          {/* Horizontal Bar Chart */}
+          <div>
+            <ResponsiveContainer width="100%" height={barHeight}>
+              <BarChart
+                layout="vertical"
+                data={chartData}
+                margin={{ top: 0, right: 16, bottom: 0, left: 0 }}
+              >
+                <XAxis
+                  type="number"
+                  tick={{ fill: "hsl(var(--foreground))", fontSize: 11 }}
+                  tickFormatter={(val: number) =>
+                    formatCurrency(String(val), currency)
+                  }
+                />
+                <YAxis
+                  type="category"
+                  dataKey="name"
+                  width={120}
+                  tick={{ fill: "hsl(var(--foreground))", fontSize: 12 }}
+                />
+                <Tooltip
+                  content={(props) => (
+                    <BarTooltip
+                      active={props.active}
+                      payload={props.payload as Array<{ value: number }>}
+                      label={props.label as string}
+                      currency={currency}
+                    />
+                  )}
+                />
+                <Bar dataKey="value" radius={[0, 4, 4, 0]}>
+                  {chartData.map((_, index) => (
+                    <Cell
+                      key={`bar-${index}`}
+                      fill={COLORS[index % COLORS.length]}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+
+          {/* Pie Chart */}
+          <div className="flex flex-col items-center">
+            <ResponsiveContainer
+              width="100%"
+              height={Math.min(barHeight, 300)}
+            >
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  dataKey="value"
+                  nameKey="name"
+                  cx="50%"
+                  cy="50%"
+                  outerRadius="75%"
+                  label={({ name, percent }) =>
+                    `${name} ${(percent * 100).toFixed(0)}%`
+                  }
+                  labelLine={false}
+                >
+                  {chartData.map((_, index) => (
+                    <Cell
+                      key={`pie-${index}`}
+                      fill={COLORS[index % COLORS.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip
+                  content={(props) => (
+                    <PieTooltip
+                      active={props.active}
+                      payload={
+                        props.payload as Array<{ name: string; value: number }>
+                      }
+                      currency={currency}
+                    />
+                  )}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+
+            {/* Legend */}
+            <div className="mt-2 flex flex-wrap justify-center gap-3">
+              {chartData.map((item, index) => (
+                <div key={item.name} className="flex items-center gap-1.5">
+                  <span
+                    className="inline-block size-3 rounded-sm"
+                    style={{
+                      backgroundColor: COLORS[index % COLORS.length],
+                    }}
+                  />
+                  <span className="text-xs text-muted-foreground">
+                    {item.name}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/dashboard/SpendingTimelineWidget.tsx
+++ b/frontend/src/components/dashboard/SpendingTimelineWidget.tsx
@@ -61,7 +61,7 @@ function buildChartData(data: SpendingTimelineResponse): ChartEntry[] {
 
 interface CustomTooltipProps {
   active?: boolean;
-  payload?: Array<{ value: number; dataKey: string; color: string }>;
+  payload?: Array<{ value: number | null; dataKey: string; color: string }>;
   label?: string;
   currency: string;
 }
@@ -76,12 +76,15 @@ function TimelineTooltip({
   return (
     <div className="rounded-md border bg-background px-3 py-2 text-sm shadow-md">
       <p className="mb-1 font-medium">{label}</p>
-      {payload.map((entry) => (
-        <p key={entry.dataKey} style={{ color: entry.color }}>
-          {entry.dataKey === "current" ? "This month" : "Last month"}:{" "}
-          {formatCurrency(String(entry.value), currency)}
-        </p>
-      ))}
+      {payload.map((entry) => {
+        if (entry.value == null) return null;
+        return (
+          <p key={entry.dataKey} style={{ color: entry.color }}>
+            {entry.dataKey === "current" ? "This month" : "Last month"}:{" "}
+            {formatCurrency(String(entry.value), currency)}
+          </p>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/SpendingTimelineWidget.tsx
+++ b/frontend/src/components/dashboard/SpendingTimelineWidget.tsx
@@ -1,0 +1,190 @@
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
+import { format, parseISO } from "date-fns";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/format";
+import type { SpendingTimelineResponse } from "@/api/types";
+
+interface Props {
+  data: SpendingTimelineResponse;
+}
+
+interface ChartEntry {
+  day: number;
+  label: string;
+  current: number;
+  previous: number | null;
+}
+
+function buildChartData(data: SpendingTimelineResponse): ChartEntry[] {
+  const currentMap = new Map<number, number>();
+  const previousMap = new Map<number, number>();
+
+  for (const entry of data.current_period) {
+    const d = parseISO(entry.spending_date);
+    currentMap.set(d.getDate(), Number(entry.cumulative_total));
+  }
+
+  for (const entry of data.previous_period) {
+    const d = parseISO(entry.spending_date);
+    previousMap.set(d.getDate(), Number(entry.cumulative_total));
+  }
+
+  // Build entries for all days that have data in either period
+  const allDays = new Set([...currentMap.keys(), ...previousMap.keys()]);
+  const sortedDays = [...allDays].sort((a, b) => a - b);
+
+  let lastCurrent = 0;
+  let lastPrevious: number | null = null;
+
+  return sortedDays.map((day) => {
+    if (currentMap.has(day)) lastCurrent = currentMap.get(day)!;
+    if (previousMap.has(day)) lastPrevious = previousMap.get(day)!;
+
+    return {
+      day,
+      label: `Day ${day}`,
+      current: currentMap.has(day) ? currentMap.get(day)! : lastCurrent,
+      previous: previousMap.has(day)
+        ? previousMap.get(day)!
+        : lastPrevious,
+    };
+  });
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: Array<{ value: number; dataKey: string; color: string }>;
+  label?: string;
+  currency: string;
+}
+
+function TimelineTooltip({
+  active,
+  payload,
+  label,
+  currency,
+}: CustomTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  return (
+    <div className="rounded-md border bg-background px-3 py-2 text-sm shadow-md">
+      <p className="mb-1 font-medium">{label}</p>
+      {payload.map((entry) => (
+        <p key={entry.dataKey} style={{ color: entry.color }}>
+          {entry.dataKey === "current" ? "This month" : "Last month"}:{" "}
+          {formatCurrency(String(entry.value), currency)}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+export function SpendingTimelineWidget({ data }: Props) {
+  const chartData = buildChartData(data);
+  const projectedTotal = data.projected_total
+    ? Number(data.projected_total)
+    : null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Spending Timeline</CardTitle>
+        <div className="flex items-baseline gap-4">
+          <p className="text-sm text-muted-foreground">
+            {format(parseISO(data.start_date), "MMM d")} –{" "}
+            {format(parseISO(data.end_date), "MMM d, yyyy")}
+          </p>
+          {projectedTotal !== null && (
+            <p className="text-sm text-muted-foreground">
+              Projected:{" "}
+              <span className="font-medium text-foreground">
+                {formatCurrency(String(projectedTotal), data.currency)}
+              </span>
+            </p>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {chartData.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No spending data for this period
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height={300}>
+            <AreaChart
+              data={chartData}
+              margin={{ top: 10, right: 16, bottom: 0, left: 0 }}
+            >
+              <XAxis
+                dataKey="label"
+                tick={{ fill: "hsl(var(--foreground))", fontSize: 11 }}
+              />
+              <YAxis
+                tick={{ fill: "hsl(var(--foreground))", fontSize: 11 }}
+                tickFormatter={(val: number) =>
+                  formatCurrency(String(val), data.currency)
+                }
+              />
+              <Tooltip
+                content={(props) => (
+                  <TimelineTooltip
+                    active={props.active}
+                    payload={
+                      props.payload as Array<{
+                        value: number;
+                        dataKey: string;
+                        color: string;
+                      }>
+                    }
+                    label={props.label as string}
+                    currency={data.currency}
+                  />
+                )}
+              />
+              {projectedTotal !== null && (
+                <ReferenceLine
+                  y={projectedTotal}
+                  stroke="hsl(var(--muted-foreground))"
+                  strokeDasharray="4 4"
+                  label={{
+                    value: "Projected",
+                    position: "right",
+                    fill: "hsl(var(--muted-foreground))",
+                    fontSize: 11,
+                  }}
+                />
+              )}
+              <Area
+                type="monotone"
+                dataKey="previous"
+                stroke="#94a3b8"
+                fill="#94a3b8"
+                fillOpacity={0.1}
+                strokeWidth={1.5}
+                strokeDasharray="4 4"
+                connectNulls
+                name="Last month"
+              />
+              <Area
+                type="monotone"
+                dataKey="current"
+                stroke="#2563eb"
+                fill="#2563eb"
+                fillOpacity={0.15}
+                strokeWidth={2}
+                name="This month"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/layout/nav-items.ts
+++ b/frontend/src/components/layout/nav-items.ts
@@ -1,15 +1,19 @@
 import {
+  LayoutDashboard,
   Wallet,
   FolderTree,
   Receipt,
   ArrowLeftRight,
   BarChart3,
+  Settings,
 } from "lucide-react";
 
 export const navItems = [
+  { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { to: "/accounts", label: "Accounts", icon: Wallet },
   { to: "/categories", label: "Categories", icon: FolderTree },
   { to: "/postings", label: "Postings", icon: Receipt },
   { to: "/transfers", label: "Transfers", icon: ArrowLeftRight },
   { to: "/reports", label: "Reports", icon: BarChart3 },
+  { to: "/settings", label: "Settings", icon: Settings },
 ] as const;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -13,7 +13,12 @@ import {
 import { parseApiError } from "@/lib/errors";
 
 export default function DashboardPage() {
-  const { data: settings, isLoading: settingsLoading } = useSettings();
+  const {
+    data: settings,
+    isLoading: settingsLoading,
+    isError: settingsError,
+    error: settingsErr,
+  } = useSettings();
   const currency = settings?.primary_currency ?? "EUR";
 
   const {
@@ -39,8 +44,8 @@ export default function DashboardPage() {
 
   const isLoading =
     settingsLoading || incomeLoading || categoriesLoading || timelineLoading;
-  const hasError = incomeError || categoriesError || timelineError;
-  const firstError = incomeErr || categoriesErr || timelineErr;
+  const hasError = settingsError || incomeError || categoriesError || timelineError;
+  const firstError = settingsErr || incomeErr || categoriesErr || timelineErr;
 
   if (isLoading) return <PageLoader />;
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,89 @@
+import { AlertCircle, LayoutDashboard } from "lucide-react";
+import { PageLoader } from "@/components/shared/PageLoader";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { IncomeVsSpendingWidget } from "@/components/dashboard/IncomeVsSpendingWidget";
+import { SpendingByCategoriesWidget } from "@/components/dashboard/SpendingByCategoriesWidget";
+import { SpendingTimelineWidget } from "@/components/dashboard/SpendingTimelineWidget";
+import {
+  useIncomeVsSpending,
+  useSpendingByCategories,
+  useSpendingTimeline,
+  useSettings,
+} from "@/api/hooks";
+import { parseApiError } from "@/lib/errors";
+
+export default function DashboardPage() {
+  const { data: settings, isLoading: settingsLoading } = useSettings();
+  const currency = settings?.primary_currency ?? "EUR";
+
+  const {
+    data: incomeData,
+    isLoading: incomeLoading,
+    isError: incomeError,
+    error: incomeErr,
+  } = useIncomeVsSpending(currency);
+
+  const {
+    data: categoriesData,
+    isLoading: categoriesLoading,
+    isError: categoriesError,
+    error: categoriesErr,
+  } = useSpendingByCategories(currency);
+
+  const {
+    data: timelineData,
+    isLoading: timelineLoading,
+    isError: timelineError,
+    error: timelineErr,
+  } = useSpendingTimeline(currency);
+
+  const isLoading =
+    settingsLoading || incomeLoading || categoriesLoading || timelineLoading;
+  const hasError = incomeError || categoriesError || timelineError;
+  const firstError = incomeErr || categoriesErr || timelineErr;
+
+  if (isLoading) return <PageLoader />;
+
+  if (hasError) {
+    return (
+      <EmptyState
+        icon={AlertCircle}
+        title="Failed to load dashboard"
+        description={parseApiError(firstError)}
+      />
+    );
+  }
+
+  const hasNoData =
+    incomeData &&
+    Number(incomeData.total_income) === 0 &&
+    Number(incomeData.total_spending) === 0 &&
+    (!categoriesData || categoriesData.length === 0);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Dashboard</h1>
+        <p className="text-sm text-muted-foreground">
+          Your financial overview for the current month ({currency})
+        </p>
+      </div>
+
+      {hasNoData ? (
+        <EmptyState
+          icon={LayoutDashboard}
+          title="No data yet"
+          description="Start adding postings to see your dashboard come alive."
+        />
+      ) : (
+        <>
+          {incomeData && <IncomeVsSpendingWidget data={incomeData} />}
+          {categoriesData && categoriesData.length > 0 && (
+            <SpendingByCategoriesWidget rows={categoriesData} currency={currency} />
+          )}
+          {timelineData && <SpendingTimelineWidget data={timelineData} />}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -13,7 +13,7 @@ import { PageLoader } from "@/components/shared/PageLoader";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { useSettings, useUpdateSettings } from "@/api/hooks";
 import { parseApiError } from "@/lib/errors";
-import { toast } from "sonner";
+import { showToast } from "@/lib/toast";
 
 const CURRENCIES = ["USD", "EUR", "GBP", "RUB", "CHF", "JPY", "CNY"];
 
@@ -33,10 +33,10 @@ export default function SettingsPage() {
       { primary_currency: selectedCurrency },
       {
         onSuccess: () => {
-          toast.success("Settings saved");
+          showToast.success("Settings saved");
         },
         onError: (err) => {
-          toast.error(parseApiError(err));
+          showToast.error(parseApiError(err));
         },
       },
     );

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,103 @@
+import { useState, useEffect } from "react";
+import { Settings, AlertCircle, Check } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { PageLoader } from "@/components/shared/PageLoader";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { useSettings, useUpdateSettings } from "@/api/hooks";
+import { parseApiError } from "@/lib/errors";
+import { toast } from "sonner";
+
+const CURRENCIES = ["USD", "EUR", "GBP", "RUB", "CHF", "JPY", "CNY"];
+
+export default function SettingsPage() {
+  const { data, isLoading, isError, error } = useSettings();
+  const updateSettings = useUpdateSettings();
+  const [selectedCurrency, setSelectedCurrency] = useState<string>("");
+
+  useEffect(() => {
+    if (data) {
+      setSelectedCurrency(data.primary_currency);
+    }
+  }, [data]);
+
+  const handleSave = () => {
+    updateSettings.mutate(
+      { primary_currency: selectedCurrency },
+      {
+        onSuccess: () => {
+          toast.success("Settings saved");
+        },
+        onError: (err) => {
+          toast.error(parseApiError(err));
+        },
+      },
+    );
+  };
+
+  if (isLoading) return <PageLoader />;
+
+  if (isError) {
+    return (
+      <EmptyState
+        icon={AlertCircle}
+        title="Failed to load settings"
+        description={parseApiError(error)}
+      />
+    );
+  }
+
+  const hasChanges = data && selectedCurrency !== data.primary_currency;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Settings</h1>
+        <p className="text-sm text-muted-foreground">
+          Configure your budget tracker preferences
+        </p>
+      </div>
+
+      <Card className="max-w-md">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Settings className="size-4" />
+            Primary Currency
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            The default currency used for dashboard widgets and reports.
+          </p>
+          <Select value={selectedCurrency} onValueChange={(v) => v && setSelectedCurrency(v)}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Select currency" />
+            </SelectTrigger>
+            <SelectContent>
+              {CURRENCIES.map((c) => (
+                <SelectItem key={c} value={c}>
+                  {c}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            onClick={handleSave}
+            disabled={!hasChanges || updateSettings.isPending}
+            size="sm"
+          >
+            <Check className="mr-1 size-4" />
+            {updateSettings.isPending ? "Saving..." : "Save"}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -3,11 +3,13 @@ import { createBrowserRouter, Navigate } from "react-router-dom";
 import { AuthLayout } from "@/components/layout/AuthLayout";
 
 const LoginPage = lazy(() => import("@/pages/LoginPage"));
+const DashboardPage = lazy(() => import("@/pages/DashboardPage"));
 const AccountsPage = lazy(() => import("@/pages/AccountsPage"));
 const CategoriesPage = lazy(() => import("@/pages/CategoriesPage"));
 const PostingsPage = lazy(() => import("@/pages/PostingsPage"));
 const TransfersPage = lazy(() => import("@/pages/TransfersPage"));
 const ReportsPage = lazy(() => import("@/pages/ReportsPage"));
+const SettingsPage = lazy(() => import("@/pages/SettingsPage"));
 
 function SuspenseWrapper({ children }: { children: ReactNode }) {
   return <Suspense fallback={null}>{children}</Suspense>;
@@ -25,7 +27,15 @@ export const router = createBrowserRouter([
   {
     element: <AuthLayout />,
     children: [
-      { index: true, element: <Navigate to="/accounts" replace /> },
+      { index: true, element: <Navigate to="/dashboard" replace /> },
+      {
+        path: "dashboard",
+        element: (
+          <SuspenseWrapper>
+            <DashboardPage />
+          </SuspenseWrapper>
+        ),
+      },
       {
         path: "accounts",
         element: (
@@ -63,6 +73,14 @@ export const router = createBrowserRouter([
         element: (
           <SuspenseWrapper>
             <ReportsPage />
+          </SuspenseWrapper>
+        ),
+      },
+      {
+        path: "settings",
+        element: (
+          <SuspenseWrapper>
+            <SettingsPage />
           </SuspenseWrapper>
         ),
       },


### PR DESCRIPTION
## Summary
- **Dashboard API endpoints**: income-vs-spending, spending-by-categories, spending-timeline with projection calculation
- **Settings API endpoints**: GET/PATCH /settings for primary currency preference
- **Dashboard page**: ZenMoney-style homepage with Income vs Spending cards, Spending by Categories (bar + pie charts), and Spending Timeline (area chart with projected total)
- **Settings page**: Primary currency selector with save functionality
- **Navigation**: Dashboard as new homepage, Settings added to sidebar

## Test plan
- [x] 15 new e2e tests (11 dashboard + 4 settings) — all pass
- [x] Full backend suite: 401 tests pass
- [x] Frontend builds cleanly with `make fe-build`
- [ ] Manual verification of dashboard widgets with real data
- [ ] Verify Settings page saves and loads currency preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)