### PR TITLE
feat: separate local dev and production database environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ wheels/
 
 # Environment
 .env
+.env.local
 
 # Coverage reports
 .coverage

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,10 @@ install:
 	cd backend && uv sync
 	cd frontend && npm ci
 
+ENV_FILE := $(shell test -f backend/.env.local && echo .env.local || echo .env)
+
 run:
-	cd backend && uv run --env-file .env fastapi dev app/main.py
+	cd backend && uv run --env-file $(ENV_FILE) fastapi dev app/main.py
 
 test:
 	cd backend && uv run pytest$(if $(V), -v)


### PR DESCRIPTION
## Summary
- `make run` now prefers `backend/.env.local` over `backend/.env`, so local dev uses local Postgres by default instead of the production Neon database
- `.env.local` added to `.gitignore` to prevent accidental commits of local overrides
- Developers create their own `backend/.env.local` (template in `.env.example`) — production `.env` remains untouched

## Test plan
- [x] `make -n run` with `.env.local` present → uses `.env.local`
- [x] `make -n run` without `.env.local` → falls back to `.env`
- [x] `git check-ignore backend/.env.local` → properly ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)