### PR TITLE
feat: payee autocomplete with frequency-ranked suggestions

### DIFF
--- a/backend/alembic/versions/0003_add_payee_index.py
+++ b/backend/alembic/versions/0003_add_payee_index.py
@@ -18,8 +18,8 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.create_index("ix_posting_payee", "posting", ["payee"])
+    op.execute("CREATE INDEX ix_posting_payee_lower ON posting (lower(payee) text_pattern_ops)")
 
 
 def downgrade() -> None:
-    op.drop_index("ix_posting_payee", table_name="posting")
+    op.drop_index("ix_posting_payee_lower", table_name="posting")

--- a/backend/alembic/versions/0003_add_payee_index.py
+++ b/backend/alembic/versions/0003_add_payee_index.py
@@ -1,0 +1,25 @@
+"""add payee index
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-03-18 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_posting_payee", "posting", ["payee"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_posting_payee", table_name="posting")

--- a/backend/app/adapters/account_repository.py
+++ b/backend/app/adapters/account_repository.py
@@ -84,12 +84,16 @@ class SqlAlchemyAccountRepository(AbstractAccountRepository):
     def suggest_payees(self, prefix: str, limit: int = 10) -> list[str]:
         from sqlalchemy import func
 
+        # Escape LIKE metacharacters so %, _ in user input match literally
+        escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        pattern = f"{escaped.lower()}%"
+
         stmt = (
             select(postings.c.payee)
-            .where(postings.c.payee.ilike(f"{prefix}%"))
+            .where(func.lower(postings.c.payee).like(pattern))
             .where(postings.c.payee.isnot(None))
             .group_by(postings.c.payee)
-            .order_by(func.count().desc())
+            .order_by(func.count().desc(), postings.c.payee.asc())
             .limit(limit)
         )
         return list(self.session.execute(stmt).scalars().all())

--- a/backend/app/adapters/account_repository.py
+++ b/backend/app/adapters/account_repository.py
@@ -80,3 +80,16 @@ class SqlAlchemyAccountRepository(AbstractAccountRepository):
             delete(postings).where(postings.c.posting_id == posting_id)
         )
         return result.rowcount > 0
+
+    def suggest_payees(self, prefix: str, limit: int = 10) -> list[str]:
+        from sqlalchemy import func
+
+        stmt = (
+            select(postings.c.payee)
+            .where(postings.c.payee.ilike(f"{prefix}%"))
+            .where(postings.c.payee.isnot(None))
+            .group_by(postings.c.payee)
+            .order_by(func.count().desc())
+            .limit(limit)
+        )
+        return list(self.session.execute(stmt).scalars().all())

--- a/backend/app/adapters/orm.py
+++ b/backend/app/adapters/orm.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Table, Column, ForeignKey, UniqueConstraint, Index
+from sqlalchemy import Table, Column, ForeignKey, UniqueConstraint, Index, func
 from sqlalchemy import Boolean, String, Numeric, Date, text
 from sqlalchemy.orm import registry, relationship, backref
 
@@ -49,7 +49,7 @@ postings = Table(
     Column("description", String(500), nullable=True),
 )
 
-Index("ix_posting_payee", postings.c.payee)
+Index("ix_posting_payee_lower", func.lower(postings.c.payee))
 
 transfers = Table(
     "transfer",

--- a/backend/app/adapters/orm.py
+++ b/backend/app/adapters/orm.py
@@ -49,6 +49,8 @@ postings = Table(
     Column("description", String(500), nullable=True),
 )
 
+Index("ix_posting_payee", postings.c.payee)
+
 transfers = Table(
     "transfer",
     metadata,

--- a/backend/app/api/routers/postings.py
+++ b/backend/app/api/routers/postings.py
@@ -22,6 +22,7 @@ from app.service_layer.services import create_posting
 from app.service_layer.services import delete_posting
 from app.service_layer.services import get_posting
 from app.service_layer.services import list_postings
+from app.service_layer.services import suggest_payees
 from app.service_layer.services import update_posting
 
 
@@ -41,6 +42,15 @@ def list_postings_endpoint(
     limit: int = Query(50, ge=1, le=100),
 ):
     return list_postings(uow, account_id=account_id, skip=skip, limit=limit)
+
+
+@router.get("/payees", response_model=list[str])
+def suggest_payees_endpoint(
+    uow: UoWDep,
+    q: str = Query(..., min_length=1, max_length=200, description="Prefix to search"),
+    limit: int = Query(10, ge=1, le=50),
+):
+    return suggest_payees(uow, prefix=q, limit=limit)
 
 
 @router.post("/", response_model=PostingResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/service_layer/abstract_account_repository.py
+++ b/backend/app/service_layer/abstract_account_repository.py
@@ -32,3 +32,8 @@ class AbstractAccountRepository(abc.ABC):
     def delete_posting_by_id(self, posting_id: str) -> bool:
         """Delete a posting directly by ID. Returns True if found and deleted, False otherwise."""
         raise NotImplementedError()
+
+    @abc.abstractmethod
+    def suggest_payees(self, prefix: str, limit: int = 10) -> list[str]:
+        """Return distinct payee values matching prefix, ordered by frequency (most-used first)."""
+        raise NotImplementedError()

--- a/backend/app/service_layer/services.py
+++ b/backend/app/service_layer/services.py
@@ -297,6 +297,11 @@ def update_posting(
         return updated
 
 
+def suggest_payees(uow: AbstractUnitOfWork, *, prefix: str, limit: int = 10) -> list[str]:
+    with uow:
+        return uow.accounts.suggest_payees(prefix, limit=limit)
+
+
 def delete_posting(uow: AbstractUnitOfWork, *, posting_id: str) -> None:
     with uow:
         found = uow.accounts.delete_posting_by_id(posting_id)

--- a/backend/tests/e2e/test_postings_api.py
+++ b/backend/tests/e2e/test_postings_api.py
@@ -611,3 +611,36 @@ def test_delete_posting_restores_account_balance(client, test_data):
     account_after_delete = client.get(f"/accounts/{account_id}")
     balance_after_delete = Decimal(account_after_delete.json()["balance"])
     assert balance_after_delete == initial_balance
+
+
+def test_suggest_payees_endpoint(client, test_data):
+    account_id = test_data["account_id"]
+    income_category_id = test_data["income_category_id"]
+
+    # Create postings with payees
+    for payee in ["Lidl", "Lidl", "Landlord", "Aldi"]:
+        client.post(
+            "/postings/",
+            json={
+                "account_id": account_id,
+                "amount": "100.00",
+                "posting_date": JAN_01.isoformat(),
+                "posting_type": "INCOME",
+                "category_id": income_category_id,
+                "payee": payee,
+            },
+        )
+
+    response = client.get("/postings/payees", params={"q": "L"})
+    assert response.status_code == 200
+    result = response.json()
+    assert isinstance(result, list)
+    # Lidl has 2 occurrences, Landlord has 1
+    assert result[0] == "Lidl"
+    assert "Landlord" in result
+    assert "Aldi" not in result  # doesn't start with "L"
+
+
+def test_suggest_payees_requires_query(client):
+    response = client.get("/postings/payees")
+    assert response.status_code == 422

--- a/backend/tests/unit/test_services.py
+++ b/backend/tests/unit/test_services.py
@@ -96,7 +96,7 @@ class FakeAccountRepository(AbstractAccountRepository):
         matches = [
             (name, cnt) for name, cnt in counts.items() if name.lower().startswith(prefix.lower())
         ]
-        matches.sort(key=lambda x: -x[1])
+        matches.sort(key=lambda x: (-x[1], x[0]))
         return [name for name, _ in matches[:limit]]
 
 
@@ -1789,3 +1789,20 @@ class TestSuggestPayees:
         uow = self._make_uow_with_postings(payees)
         result = suggest_payees(uow, prefix="Store", limit=5)
         assert len(result) == 5
+
+    def test_suggest_payees_escapes_like_wildcards(self):
+        """Prefix containing SQL LIKE wildcards (% and _) must match literally."""
+        uow = self._make_uow_with_postings(["100% Juice", "100 Montaditos", "A_B Corp", "ACB Corp"])
+        # '%' in prefix must be literal — should match "100% Juice" only
+        result = suggest_payees(uow, prefix="100%")
+        assert result == ["100% Juice"]
+        # '_' in prefix must be literal — should match "A_B Corp" only
+        result = suggest_payees(uow, prefix="A_B")
+        assert result == ["A_B Corp"]
+
+    def test_suggest_payees_stable_ordering_same_frequency(self):
+        """Payees with the same frequency should be sorted alphabetically for stable results."""
+        uow = self._make_uow_with_postings(["Zebra", "Apple", "Mango"])
+        result = suggest_payees(uow, prefix="")
+        # All have frequency 1 — should be alphabetically ordered
+        assert result == ["Apple", "Mango", "Zebra"]

--- a/backend/tests/unit/test_services.py
+++ b/backend/tests/unit/test_services.py
@@ -51,6 +51,7 @@ from app.service_layer.services import get_transfer
 from app.service_layer.services import list_transfers
 from app.service_layer.services import get_settings
 from app.service_layer.services import update_settings
+from app.service_layer.services import suggest_payees
 from tests.constants import JAN_01
 
 
@@ -86,6 +87,17 @@ class FakeAccountRepository(AbstractAccountRepository):
                 acc.remove_posting(posting_id)
                 return True
         return False
+
+    def suggest_payees(self, prefix: str, limit: int = 10) -> list[str]:
+        from collections import Counter
+
+        payees = [p.payee for a in self._accounts for p in a.postings if p.payee]
+        counts = Counter(payees)
+        matches = [
+            (name, cnt) for name, cnt in counts.items() if name.lower().startswith(prefix.lower())
+        ]
+        matches.sort(key=lambda x: -x[1])
+        return [name for name, _ in matches[:limit]]
 
 
 class FakeTransferRepository(AbstractTransferRepository):
@@ -1737,3 +1749,43 @@ class TestSettings:
             settings.primary_currency = "INVALID"
         # Original value unchanged
         assert settings.primary_currency == "EUR"
+
+
+class TestSuggestPayees:
+    def _make_uow_with_postings(self, payees: list[str]) -> FakeUnitOfWork:
+        """Helper: create a UoW with an account containing postings with given payee names."""
+        uow = FakeUnitOfWork()
+        account = create_account(uow, name="Main", currency="EUR", initial_balance=Decimal("0"))
+        for p in payees:
+            create_posting(
+                uow,
+                account_id=account.account_id,
+                amount=Decimal("10"),
+                posting_date=JAN_01,
+                posting_type=PostingType.INCOME,
+                payee=p,
+            )
+        return uow
+
+    def test_suggest_payees_returns_matching_payees_ordered_by_frequency(self):
+        uow = self._make_uow_with_postings(["Lidl", "Lidl", "Landlord", "Aldi"])
+        result = suggest_payees(uow, prefix="L")
+        # Lidl has 2 occurrences, Landlord has 1 — Lidl should come first
+        assert result == ["Lidl", "Landlord"]
+
+    def test_suggest_payees_no_matches(self):
+        uow = self._make_uow_with_postings(["Lidl", "Aldi"])
+        result = suggest_payees(uow, prefix="Xyz")
+        assert result == []
+
+    def test_suggest_payees_case_insensitive(self):
+        uow = self._make_uow_with_postings(["McDonald's"])
+        result = suggest_payees(uow, prefix="mcd")
+        assert result == ["McDonald's"]
+
+    def test_suggest_payees_respects_limit(self):
+        # Create 15 distinct payees
+        payees = [f"Store_{i:02d}" for i in range(15)]
+        uow = self._make_uow_with_postings(payees)
+        result = suggest_payees(uow, prefix="Store", limit=5)
+        assert len(result) == 5

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -151,6 +151,8 @@ export const api = {
       }),
     delete: (id: string) =>
       request<void>(`/postings/${id}`, { method: "DELETE" }),
+    suggestPayees: (q: string, limit = 10) =>
+      request<string[]>(`/postings/payees${buildQuery({ q, limit })}`),
   },
 
   transfers: {

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -182,6 +182,15 @@ export function useDeletePosting() {
   });
 }
 
+export function usePayeeSuggestions(query: string) {
+  return useQuery<string[]>({
+    queryKey: queryKeys.postings.payeeSuggestions(query),
+    queryFn: () => api.postings.suggestPayees(query),
+    enabled: query.length >= 1,
+    staleTime: 60_000,
+  });
+}
+
 // --- Transfers (useInfiniteQuery) ---
 
 export function useTransfers() {

--- a/frontend/src/api/keys.ts
+++ b/frontend/src/api/keys.ts
@@ -16,6 +16,7 @@ export const queryKeys = {
       accountId
         ? (["postings", { accountId }] as const)
         : (["postings"] as const),
+    payeeSuggestions: (q: string) => ["postings", "payees", q] as const,
   },
   transfers: {
     all: ["transfers"] as const,

--- a/frontend/src/components/postings/CreatePostingDialog.tsx
+++ b/frontend/src/components/postings/CreatePostingDialog.tsx
@@ -24,6 +24,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Calendar } from "@/components/ui/calendar";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useAccounts, useCategoryParents, useCreatePosting } from "@/api/hooks";
+import { PayeeCombobox } from "@/components/postings/PayeeCombobox";
 import { parseApiError } from "@/lib/errors";
 import { showToast } from "@/lib/toast";
 import type { PostingType } from "@/api/types";
@@ -267,10 +268,10 @@ export function CreatePostingDialog({
           {/* Payee */}
           <div className="space-y-2">
             <Label htmlFor="posting-payee">Payee (optional)</Label>
-            <Input
+            <PayeeCombobox
               id="posting-payee"
               value={payee}
-              onChange={(e) => setPayee(e.target.value)}
+              onChange={setPayee}
               placeholder="e.g. Supermarket, Employer"
               maxLength={200}
             />

--- a/frontend/src/components/postings/EditPostingDialog.tsx
+++ b/frontend/src/components/postings/EditPostingDialog.tsx
@@ -24,6 +24,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Calendar } from "@/components/ui/calendar";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useAccounts, useCategoryParents, useUpdatePosting } from "@/api/hooks";
+import { PayeeCombobox } from "@/components/postings/PayeeCombobox";
 import { parseApiError } from "@/lib/errors";
 import { showToast } from "@/lib/toast";
 import type { PostingResponse, PostingType, PostingUpdate } from "@/api/types";
@@ -258,10 +259,10 @@ export function EditPostingDialog({
           {/* Payee */}
           <div className="space-y-2">
             <Label htmlFor="edit-posting-payee">Payee (optional)</Label>
-            <Input
+            <PayeeCombobox
               id="edit-posting-payee"
               value={payee}
-              onChange={(e) => setPayee(e.target.value)}
+              onChange={setPayee}
               placeholder="e.g. Supermarket, Employer"
               maxLength={200}
             />

--- a/frontend/src/components/postings/PayeeCombobox.tsx
+++ b/frontend/src/components/postings/PayeeCombobox.tsx
@@ -1,0 +1,66 @@
+import { Combobox } from "@base-ui/react/combobox";
+import { usePayeeSuggestions } from "@/api/hooks";
+import { useDebounce } from "@/hooks/use-debounce";
+
+interface PayeeComboboxProps {
+  value: string;
+  onChange: (value: string) => void;
+  id?: string;
+  placeholder?: string;
+  maxLength?: number;
+}
+
+export function PayeeCombobox({
+  value,
+  onChange,
+  id,
+  placeholder = "e.g. Supermarket, Employer",
+  maxLength = 200,
+}: PayeeComboboxProps) {
+  const debouncedValue = useDebounce(value, 200);
+  const { data: suggestions = [] } = usePayeeSuggestions(debouncedValue);
+
+  return (
+    <Combobox.Root
+      items={suggestions}
+      inputValue={value}
+      onInputValueChange={(nextValue) => {
+        onChange(nextValue);
+      }}
+      onValueChange={(selectedItem) => {
+        if (selectedItem != null) {
+          onChange(String(selectedItem));
+        }
+      }}
+      filter={null}
+    >
+      <Combobox.Input
+        id={id}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        autoComplete="off"
+        data-slot="input"
+        className="h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 md:text-sm dark:bg-input/30"
+      />
+      {suggestions.length > 0 && (
+        <Combobox.Portal>
+          <Combobox.Positioner className="z-50 outline-none" sideOffset={4}>
+            <Combobox.Popup className="max-h-48 w-[var(--anchor-width)] overflow-y-auto overscroll-contain rounded-lg bg-popover p-1 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10">
+              <Combobox.List>
+                {(item: string) => (
+                  <Combobox.Item
+                    key={item}
+                    value={item}
+                    className="cursor-default select-none rounded-md px-2 py-1.5 text-sm outline-none transition-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+                  >
+                    {item}
+                  </Combobox.Item>
+                )}
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      )}
+    </Combobox.Root>
+  );
+}

--- a/frontend/src/components/postings/PayeeCombobox.tsx
+++ b/frontend/src/components/postings/PayeeCombobox.tsx
@@ -45,7 +45,7 @@ export function PayeeCombobox({
       {suggestions.length > 0 && (
         <Combobox.Portal>
           <Combobox.Positioner className="z-50 outline-none" sideOffset={4}>
-            <Combobox.Popup className="max-h-48 w-[var(--anchor-width)] overflow-y-auto overscroll-contain rounded-lg bg-popover p-1 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10">
+            <Combobox.Popup className="max-h-48 w-(--anchor-width) overflow-y-auto overscroll-contain rounded-lg bg-popover p-1 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10">
               <Combobox.List>
                 {(item: string) => (
                   <Combobox.Item

--- a/frontend/src/hooks/use-debounce.ts
+++ b/frontend/src/hooks/use-debounce.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Returns a debounced version of `value` that only updates
+ * after `delay` milliseconds of inactivity.
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary
- Add `GET /postings/payees?q=<prefix>&limit=<n>` endpoint that queries distinct historical payee values, ranked by usage frequency (most-used first), filtered by case-insensitive prefix match
- Add B-tree index on `posting.payee` column (Alembic migration `0003_add_payee_index`)
- Add `PayeeCombobox` frontend component using Base UI's native `Combobox` with 200ms debounced input, server-side filtering, keyboard navigation, and full ARIA support
- Wire `PayeeCombobox` into both Create Posting and Edit Posting dialogs, replacing the plain text input

## Test plan
- [x] 4 unit tests: prefix matching, frequency ordering, case insensitivity, limit enforcement (430 total pass)
- [x] 2 e2e tests: endpoint returns correct results, rejects missing query param
- [x] Backend pre-commit checks pass (ruff check, ruff format, pytest, ty)
- [x] Frontend builds with zero TypeScript errors
- [x] Frontend lint clean on new files
- [ ] Manual: type "L" in payee field → dropdown shows payees starting with "L" ranked by frequency
- [ ] Manual: arrow-key through suggestions, Enter selects, Escape closes
- [ ] Manual: type a brand-new payee → no dropdown interference, value accepted
- [ ] Manual: edit posting dialog → same autocomplete with pre-filled value

🤖 Generated with [Claude Code](https://claude.com/claude-code)