### PR TITLE
fix: show account/category names instead of UUIDs in selects

### DIFF
--- a/frontend/src/components/postings/CreatePostingDialog.tsx
+++ b/frontend/src/components/postings/CreatePostingDialog.tsx
@@ -195,7 +195,13 @@ export function CreatePostingDialog({
               required
             >
               <SelectTrigger id="posting-parent-category" className="w-full">
-                <SelectValue placeholder="Select category" />
+                <SelectValue placeholder="Select category">
+                  {(value: string | null) => {
+                    if (!value) return null;
+                    const match = filteredParents.find((p) => p.category_id === value);
+                    return match?.name ?? "Loading…";
+                  }}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {filteredParents.map((p) => (
@@ -218,7 +224,13 @@ export function CreatePostingDialog({
                 required
               >
                 <SelectTrigger id="posting-subcategory" className="w-full">
-                  <SelectValue placeholder="Select subcategory" />
+                  <SelectValue placeholder="Select subcategory">
+                    {(value: string | null) => {
+                      if (!value) return null;
+                      const match = subcategories.find((c) => c.category_id === value);
+                      return match?.name ?? "Loading…";
+                    }}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {subcategories.map((child) => (

--- a/frontend/src/components/postings/CreatePostingDialog.tsx
+++ b/frontend/src/components/postings/CreatePostingDialog.tsx
@@ -169,7 +169,8 @@ export function CreatePostingDialog({
                   {(value: string | null) => {
                     if (!value) return null;
                     const match = (accounts ?? []).find((a) => a.account_id === value);
-                    return match ? `${match.name} (${match.currency})` : "Loading…";
+                    if (match) return `${match.name} (${match.currency})`;
+                    return accounts === undefined ? "Loading…" : "Unknown account";
                   }}
                 </SelectValue>
               </SelectTrigger>
@@ -199,7 +200,8 @@ export function CreatePostingDialog({
                   {(value: string | null) => {
                     if (!value) return null;
                     const match = filteredParents.find((p) => p.category_id === value);
-                    return match?.name ?? "Loading…";
+                    if (match) return match.name;
+                    return categoryParents === undefined ? "Loading…" : "Unknown category";
                   }}
                 </SelectValue>
               </SelectTrigger>
@@ -228,7 +230,7 @@ export function CreatePostingDialog({
                     {(value: string | null) => {
                       if (!value) return null;
                       const match = subcategories.find((c) => c.category_id === value);
-                      return match?.name ?? "Loading…";
+                      return match?.name ?? "Unknown subcategory";
                     }}
                   </SelectValue>
                 </SelectTrigger>

--- a/frontend/src/components/postings/EditPostingDialog.tsx
+++ b/frontend/src/components/postings/EditPostingDialog.tsx
@@ -221,7 +221,8 @@ export function EditPostingDialog({
                   {(value: string | null) => {
                     if (!value) return null;
                     const match = filteredParents.find((p) => p.category_id === value);
-                    return match?.name ?? "Loading…";
+                    if (match) return match.name;
+                    return categoryParents === undefined ? "Loading…" : "Unknown category";
                   }}
                 </SelectValue>
               </SelectTrigger>
@@ -249,7 +250,7 @@ export function EditPostingDialog({
                     {(value: string | null) => {
                       if (!value) return null;
                       const match = subcategories.find((c) => c.category_id === value);
-                      return match?.name ?? "Loading…";
+                      return match?.name ?? "Unknown subcategory";
                     }}
                   </SelectValue>
                 </SelectTrigger>

--- a/frontend/src/components/postings/EditPostingDialog.tsx
+++ b/frontend/src/components/postings/EditPostingDialog.tsx
@@ -217,7 +217,13 @@ export function EditPostingDialog({
               onValueChange={handleParentCategoryChange}
             >
               <SelectTrigger id="edit-posting-parent-category" className="w-full">
-                <SelectValue placeholder="No category" />
+                <SelectValue placeholder="No category">
+                  {(value: string | null) => {
+                    if (!value) return null;
+                    const match = filteredParents.find((p) => p.category_id === value);
+                    return match?.name ?? "Loading…";
+                  }}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {filteredParents.map((p) => (
@@ -239,7 +245,13 @@ export function EditPostingDialog({
                 disabled={!parentCategoryId}
               >
                 <SelectTrigger id="edit-posting-subcategory" className="w-full">
-                  <SelectValue placeholder="Select subcategory" />
+                  <SelectValue placeholder="Select subcategory">
+                    {(value: string | null) => {
+                      if (!value) return null;
+                      const match = subcategories.find((c) => c.category_id === value);
+                      return match?.name ?? "Loading…";
+                    }}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {subcategories.map((child) => (

--- a/frontend/src/components/transfers/CreateTransferDialog.tsx
+++ b/frontend/src/components/transfers/CreateTransferDialog.tsx
@@ -173,7 +173,8 @@ export function CreateTransferDialog({
                   {(value: string | null) => {
                     if (!value) return null;
                     const match = accounts?.find((a) => a.account_id === value);
-                    return match ? `${match.name} (${match.currency})` : "Loading…";
+                    if (match) return `${match.name} (${match.currency})`;
+                    return accounts === undefined ? "Loading…" : "Unknown account";
                   }}
                 </SelectValue>
               </SelectTrigger>
@@ -198,7 +199,8 @@ export function CreateTransferDialog({
                   {(value: string | null) => {
                     if (!value) return null;
                     const match = accounts?.find((a) => a.account_id === value);
-                    return match ? `${match.name} (${match.currency})` : "Loading…";
+                    if (match) return `${match.name} (${match.currency})`;
+                    return accounts === undefined ? "Loading…" : "Unknown account";
                   }}
                 </SelectValue>
               </SelectTrigger>

--- a/frontend/src/components/transfers/CreateTransferDialog.tsx
+++ b/frontend/src/components/transfers/CreateTransferDialog.tsx
@@ -169,7 +169,13 @@ export function CreateTransferDialog({
             <Label htmlFor="source-account">Source Account</Label>
             <Select value={sourceAccountId} onValueChange={handleSourceChange}>
               <SelectTrigger id="source-account" className="w-full">
-                <SelectValue placeholder="Select source account" />
+                <SelectValue placeholder="Select source account">
+                  {(value: string | null) => {
+                    if (!value) return null;
+                    const match = accounts?.find((a) => a.account_id === value);
+                    return match ? `${match.name} (${match.currency})` : "Loading…";
+                  }}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {accounts?.map((account) => {
@@ -188,7 +194,13 @@ export function CreateTransferDialog({
             <Label htmlFor="dest-account">Destination Account</Label>
             <Select value={destAccountId} onValueChange={handleDestChange}>
               <SelectTrigger id="dest-account" className="w-full">
-                <SelectValue placeholder="Select destination account" />
+                <SelectValue placeholder="Select destination account">
+                  {(value: string | null) => {
+                    if (!value) return null;
+                    const match = accounts?.find((a) => a.account_id === value);
+                    return match ? `${match.name} (${match.currency})` : "Loading…";
+                  }}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {accounts?.map((account) => {


### PR DESCRIPTION
## Summary
- Fix `SelectValue` in 6 locations across 3 dialog components to show human-readable names instead of raw UUIDs
- Root cause: `@base-ui/react` `Select.Value` requires a render function as children to display custom labels — the `label` prop on `SelectItem` alone does not populate the trigger text
- Applied the same render-function pattern already working in CreatePostingDialog's account select

## Fixed locations
| File | Element |
|------|---------|
| `CreateTransferDialog.tsx` | Source Account |
| `CreateTransferDialog.tsx` | Destination Account |
| `CreatePostingDialog.tsx` | Category |
| `CreatePostingDialog.tsx` | Subcategory |
| `EditPostingDialog.tsx` | Category |
| `EditPostingDialog.tsx` | Subcategory |

## Test plan
- [x] Frontend builds with zero TypeScript errors
- [x] No backend changes — all 432 backend tests unaffected
- [ ] Manual: Create Transfer → select source/dest accounts → trigger shows "Name (CURRENCY)"
- [ ] Manual: Create Posting → select category/subcategory → trigger shows category name
- [ ] Manual: Edit Posting → category/subcategory pre-filled and showing names
- [ ] Manual: Existing working account select in CreatePostingDialog still works (no regression)

Closes bt-nxd

🤖 Generated with [Claude Code](https://claude.com/claude-code)